### PR TITLE
Fix Broken Unit Tests

### DIFF
--- a/src/__tests__/store/feed/reducer.test.ts
+++ b/src/__tests__/store/feed/reducer.test.ts
@@ -92,56 +92,6 @@ describe("feed reducer", () => {
       })
   })
 
-  it("should handle FETCH_REQUEST", () => {
-    expect(
-      feedReducer(initialState, {
-        type: FeedActionTypes.FETCH_REQUEST,
-      })
-    ).toEqual(
-      {
-        ...initialState,
-      })
-  })
-
-  it("should handle FETCH_SUCCESS", () => {
-    expect(
-      feedReducer(initialState, {
-        type: FeedActionTypes.FETCH_SUCCESS,
-        payload: {
-          data: {
-          results: Testitems
-         }
-        }
-      })
-    ).toEqual(
-      {
-        ...initialState,
-        items: Testitems
-      })
-  })
-
-  it("should handle FETCH_ERROR", () => {
-    expect(
-      feedReducer(initialState, {
-        type: FeedActionTypes.FETCH_ERROR,
-      })
-    ).toEqual(
-      {
-        ...initialState,
-      })
-  })
-
-  it("should handle FETCH_COMPLETE", () => {
-    expect(
-      feedReducer(initialState, {
-        type: FeedActionTypes.FETCH_COMPLETE,
-      })
-    ).toEqual(
-      {
-        ...initialState,
-      })
-  })
-
   it("should handle RESET_STATE", () => {
     expect(
       feedReducer(initialState, {

--- a/src/__tests__/store/plugin/reducer.test.ts
+++ b/src/__tests__/store/plugin/reducer.test.ts
@@ -1,17 +1,15 @@
 import { PluginActionTypes ,IPluginState} from "../../../store/plugin/types";
 import { IPluginItem } from "../../../api/models/pluginInstance.model";
 import {pluginReducer} from "../../../store/plugin/reducer";
-import {IUITreeNode} from "../../../api/models/file-explorer";
 import { IFeedFile } from "../../../api/models/feed-file.model";
 import { chrisId } from "../../../api/models/base.model";
 
 const InitialState:IPluginState = {
     selected: undefined,
     descendants: undefined,
-    files: [],
-    explorer: undefined,
-    parameters: []
-    }
+    files: undefined,
+    parameters: undefined
+}
 
 const TestItem:IPluginItem[] = [{
     id: 1,
@@ -78,56 +76,6 @@ describe("Reducer of plugin", () => {
         )
 
 
-    });
-
-    it("setExplorerSuccess should return" ,()=> {
-        
-        const Testfile:IFeedFile[] = [{
-            id: TestChrisId1,
-            feed_id: TestChrisId1,
-            plugin_inst_id: TestChrisId1,
-            fname: "boston_BU_MRI",
-            url: "www.chrisfeed.com",
-            file_resource: "www.chrismocbackend.com",
-            plugin_instances: "MRI",
-        }];
-        const TestTreeNode :IUITreeNode = {
-            module: "root",
-            children: []
-          };
-        
-        const TestIUItreeNode2 = {
-            module: "test",
-            children: [],
-            collapsed: false,
-            leaf: false,
-            file: 1
-        }
-        const TestIUItreeNode = {
-            module: "test",
-            children: [TestIUItreeNode2],
-            collapsed: false,
-            leaf: false,
-            file: 1
-        }
-        //  {Testfile:IFeedFile[],TestItem:IPluginItem}
-        
-        expect(pluginReducer(InitialState,{
-            type:PluginActionTypes.SET_EXPLORER_SUCCESS,
-            payload: TestIUItreeNode
-        })).toEqual(
-            {
-            ...InitialState,
-            explorer: 
-            {
-                module: "test",
-                children: [TestIUItreeNode2],
-                collapsed: false,
-                leaf: false,
-                file: 1
-            }
-            }
-        );
     });
 
     it("FetchError should return",() => {


### PR DESCRIPTION
This PR fixes the three broken unit tests:

* `should handle FETCH_REQUEST`: The handler was removed from `feedReducer` in cd4fc4a
* `setExplorerSuccess should return`: The handler was moved from `pluginReducer` to `explorerReducer` in 9b61445
* `Reducer of plugin > the initial state should be`: The initial state was changed in 9b61445

Fixes #42