### PR TITLE
File viewer fix

### DIFF
--- a/src/components/dicomViewer/DcmImage.tsx
+++ b/src/components/dicomViewer/DcmImage.tsx
@@ -6,7 +6,7 @@ import * as AMI from "ami.js";
 import {
   orthographicCameraFactory,
   stackHelperFactory,
-  trackballOrthoControlFactory
+  trackballOrthoControlFactory,
 } from "ami.js";
 import "./amiViewer.scss";
 
@@ -18,6 +18,11 @@ type AllProps = {
 class DcmImage extends React.Component<AllProps> {
   private _removeResizeEventListener?: () => void = undefined;
   // dynamicImagePixelData: string | ArrayBuffer | null = null;
+  private containerRef: React.RefObject<HTMLInputElement>;
+  constructor(props: AllProps) {
+    super(props);
+    this.containerRef = React.createRef();
+  }
   componentDidMount() {
     const { file } = this.props;
     if (!!file.blob) {
@@ -30,14 +35,14 @@ class DcmImage extends React.Component<AllProps> {
     return (
       <div className="ami-viewer">
         <div id="my-gui-container" />
-        <div id="container" />
+        <div ref={this.containerRef} id="container" />
       </div>
     );
   }
 
   // Description: Run AMI CODE ***** working to be abstracted out
   initAmi = (file: string) => {
-    const container = document.getElementById("container");
+    const container = this.containerRef.current;
     if (!!container) {
       const renderer = new THREE.WebGLRenderer({
         antialias: true,
@@ -50,14 +55,16 @@ class DcmImage extends React.Component<AllProps> {
       const scene = new THREE.Scene();
       const OrthograhicCamera = orthographicCameraFactory(THREE);
       const width = container.clientWidth,
-      height = container.clientHeight;
+        height = container.clientHeight;
       // type => ( left : number, right : number, top : number, bottom : number, near : number =  0.1, far : number = 2000 ) => void
       const camera = new OrthograhicCamera(
         width / -2,
         width / 2,
         height / 2,
         height / -2,
-         0.1, 2000);
+        0.1,
+        2000
+      );
 
       // Setup controls
       const TrackballOrthoControl = trackballOrthoControlFactory(THREE);
@@ -104,7 +111,11 @@ class DcmImage extends React.Component<AllProps> {
 
           const box = {
             center: stack.worldCenter().clone(),
-            halfDimensions: new THREE.Vector3(lpsDims.x + 10, lpsDims.y + 10, lpsDims.z + 10),
+            halfDimensions: new THREE.Vector3(
+              lpsDims.x + 10,
+              lpsDims.y + 10,
+              lpsDims.z + 10
+            ),
           };
 
           // init and zoom
@@ -120,8 +131,10 @@ class DcmImage extends React.Component<AllProps> {
 
           // Bind event handler at the end
           window.addEventListener("resize", onWindowResize, false);
-          this._removeResizeEventListener = () => window.removeEventListener("resize", onWindowResize, false);
-        }).catch((error: any) => {
+          this._removeResizeEventListener = () =>
+            window.removeEventListener("resize", onWindowResize, false);
+        })
+        .catch((error: any) => {
           console.error(error);
         });
 
@@ -172,10 +185,7 @@ class DcmImage extends React.Component<AllProps> {
           camera.rotate();
         });
 
-        cameraFolder
-          .add(camera, "angle", 0, 360)
-          .step(1)
-          .listen();
+        cameraFolder.add(camera, "angle", 0, 360).step(1).listen();
 
         const orientationUpdate = cameraFolder.add(camUtils, "orientation", [
           "default",
@@ -190,7 +200,10 @@ class DcmImage extends React.Component<AllProps> {
           stackHelper.orientation = camera.stackOrientation;
         });
 
-        const conventionUpdate = cameraFolder.add(camUtils, "convention", ["radio", "neuro"]);
+        const conventionUpdate = cameraFolder.add(camUtils, "convention", [
+          "radio",
+          "neuro",
+        ]);
         conventionUpdate.onChange((value: any) => {
           camera.convention = value;
           camera.update();
@@ -211,7 +224,7 @@ class DcmImage extends React.Component<AllProps> {
         stackFolder.open();
       };
     }
-  }
+  };
   componentWillUnmount() {
     !!this._removeResizeEventListener && this._removeResizeEventListener();
   }
@@ -222,8 +235,7 @@ const colors = {
   darkGrey: 0x353535,
   white: 0xffffff,
   black: 0x000000,
-  red: 0xff0000
+  red: 0xff0000,
 };
-
 
 export default DcmImage;

--- a/src/components/explorer/FileDetailView.tsx
+++ b/src/components/explorer/FileDetailView.tsx
@@ -3,12 +3,12 @@ import { Button } from "@patternfly/react-core";
 import { DownloadIcon, ExpandIcon } from "@patternfly/react-icons";
 import {
   getFileExtension,
-  IUITreeNode
+  IUITreeNode,
 } from "../../api/models/file-explorer.model";
 import { IFileBlob } from "../../api/models/file-viewer.model";
 
 import FileViewerModel, {
-  fileViewerMap
+  fileViewerMap,
 } from "../../api/models/file-viewer.model";
 import { LoadingSpinner } from "..";
 import ViewerDisplay from "./displays/ViewerDisplay";
@@ -32,7 +32,7 @@ class FileDetailView extends React.Component<AllProps, IFileBlob> {
     blobName: "",
     blobText: null,
     fileType: "",
-    file: undefined
+    file: undefined,
   };
 
   render() {
@@ -46,7 +46,7 @@ class FileDetailView extends React.Component<AllProps, IFileBlob> {
         const viewerName = fileViewerMap[this.state.fileType];
 
         return (
-          <div className={viewerName.toLowerCase()}>
+          <div className={viewerName ? viewerName.toLowerCase() : ""}>
             {this.renderHeader()}
             <ViewerDisplay tag={viewerName} galleryItem={this.state} />
           </div>
@@ -87,7 +87,7 @@ class FileDetailView extends React.Component<AllProps, IFileBlob> {
               blobName: fileName,
               fileType,
               blobText,
-              file: Object.assign({}, selectedFile.file.data)
+              file: Object.assign({}, selectedFile.file.data),
             });
         });
         reader.readAsText(result);

--- a/src/components/explorer/displays/CatchallDisplay.tsx
+++ b/src/components/explorer/displays/CatchallDisplay.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { getFileExtension } from "../../../api/models/file-explorer.model";
+
 import { IGalleryItem } from "../../../api/models/gallery.model";
 import { DownloadIcon } from "@patternfly/react-icons";
 import { Alert, Button } from "@patternfly/react-core";

--- a/src/components/explorer/displays/CatchallDisplay.tsx
+++ b/src/components/explorer/displays/CatchallDisplay.tsx
@@ -8,36 +8,45 @@ type AllProps = {
   galleryItem: IGalleryItem;
 };
 // Description: No preview message available for this file type
-const CatchallDisplay: React.FunctionComponent<AllProps> = (props: AllProps) => {
-    const noPreviewMessage = () => {
-        const { galleryItem } = props;
-        const ext = getFileExtension(galleryItem.fileName);
-        const alertText = (
-        <React.Fragment>
-            <label>
-              <b>File Name:</b> {galleryItem.fileName}
-            </label>
-            <label>
-              <b>File Type:</b> {ext}
-            </label>
-           <Button
-              variant="primary"
-              className="float-right"
-              onClick={ () => FileViewerModel.downloadFile(galleryItem.blob, galleryItem.fileName) }
-            ><DownloadIcon /> Download</Button>
-        </React.Fragment>
-      );
-        return (
-        <div className="catchall">
-          <Alert
-            variant="info"
-            title="No preview available for file:"
-            children={alertText}
-          />
-        </div>
-      );
-    }
-    return noPreviewMessage();
-}
+const CatchallDisplay: React.FunctionComponent<AllProps> = (
+  props: AllProps
+) => {
+  const noPreviewMessage = () => {
+    const { galleryItem } = props;
+
+    const ext = galleryItem.fileType ? galleryItem.fileType : "";
+    const alertText = (
+      <React.Fragment>
+        <label>
+          <b>File Name:</b> {galleryItem.blobName}
+        </label>
+        <br></br>
+        <label>
+          <b>File Type:</b> {ext}
+        </label>
+        <Button
+          variant="primary"
+          className="float-right"
+          onClick={() =>
+            galleryItem.blobName &&
+            FileViewerModel.downloadFile(galleryItem.blob, galleryItem.blobName)
+          }
+        >
+          <DownloadIcon /> Download
+        </Button>
+      </React.Fragment>
+    );
+    return (
+      <div className="catchall">
+        <Alert
+          variant="info"
+          title="No preview available for file:"
+          children={alertText}
+        />
+      </div>
+    );
+  };
+  return noPreviewMessage();
+};
 
 export default React.memo(CatchallDisplay);

--- a/src/components/feed/CreateFeed/CreateFeed.tsx
+++ b/src/components/feed/CreateFeed/CreateFeed.tsx
@@ -8,7 +8,7 @@ import {
   UploadedFile,
   Tag,
   PluginInstance,
-  Collection
+  Collection,
 } from "@fnndsc/chrisapi";
 import { Button, Wizard } from "@patternfly/react-core";
 
@@ -55,7 +55,7 @@ function getDefaultCreateFeedData(): CreateFeedData {
     feedDescription: "",
     tags: [],
     chrisFiles: [],
-    localFiles: []
+    localFiles: [],
   };
 }
 
@@ -80,7 +80,7 @@ class CreateFeed extends React.Component<AllProps, CreateFeedState> {
       wizardOpen: false,
       saving: false,
       step: 1,
-      data: getDefaultCreateFeedData()
+      data: getDefaultCreateFeedData(),
     };
 
     this.toggleCreateWizard = this.toggleCreateWizard.bind(this);
@@ -111,7 +111,7 @@ class CreateFeed extends React.Component<AllProps, CreateFeedState> {
     this.setState({
       data: getDefaultCreateFeedData(),
       step: 1,
-      saving: false
+      saving: false,
     });
   }
 
@@ -123,8 +123,8 @@ class CreateFeed extends React.Component<AllProps, CreateFeedState> {
     if (this.state.wizardOpen) {
       this.resetState();
     }
-    this.setState(state => ({
-      wizardOpen: !state.wizardOpen
+    this.setState((state) => ({
+      wizardOpen: !state.wizardOpen,
     }));
   }
 
@@ -141,7 +141,7 @@ class CreateFeed extends React.Component<AllProps, CreateFeedState> {
       "basic-information",
       "chris-file-select",
       "local-file-upload",
-      "review"
+      "review",
     ];
     return stepNames[this.state.step - 1]; // this.state.step starts at 1
   }
@@ -161,12 +161,11 @@ class CreateFeed extends React.Component<AllProps, CreateFeedState> {
   // CHRIS FILE SELECT HANDLERS
 
   async handleChrisFileAdd(file: ChrisFile) {
-    console.log("File", file);
     this.setState({
       data: {
         ...this.state.data,
-        chrisFiles: [...this.state.data.chrisFiles, file]
-      }
+        chrisFiles: [...this.state.data.chrisFiles, file],
+      },
     });
   }
 
@@ -174,8 +173,10 @@ class CreateFeed extends React.Component<AllProps, CreateFeedState> {
     this.setState({
       data: {
         ...this.state.data,
-        chrisFiles: this.state.data.chrisFiles.filter(f => f.path !== file.path)
-      }
+        chrisFiles: this.state.data.chrisFiles.filter(
+          (f) => f.path !== file.path
+        ),
+      },
     });
   }
 
@@ -185,8 +186,8 @@ class CreateFeed extends React.Component<AllProps, CreateFeedState> {
     this.setState({
       data: {
         ...this.state.data,
-        localFiles: [...this.state.data.localFiles, ...files]
-      }
+        localFiles: [...this.state.data.localFiles, ...files],
+      },
     });
   }
   handleLocalFileRemove(fileName: string) {
@@ -194,9 +195,9 @@ class CreateFeed extends React.Component<AllProps, CreateFeedState> {
       data: {
         ...this.state.data,
         localFiles: this.state.data.localFiles.filter(
-          file => file.name !== fileName
-        )
-      }
+          (file) => file.name !== fileName
+        ),
+      },
     });
   }
 
@@ -242,15 +243,15 @@ class CreateFeed extends React.Component<AllProps, CreateFeedState> {
     const uploadedFiles = await ChrisAPIClient.getClient().getUploadedFiles();
 
     return await Promise.all(
-      files.map(async file => {
+      files.map(async (file) => {
         const pathName = this.getDataFileTempPath(file, tempDirName);
         const blob = await this.getDataFileBlob(file);
         return await uploadedFiles.post(
           {
-            upload_path: pathName
+            upload_path: pathName,
           },
           {
-            fname: blob
+            fname: blob,
           }
         );
       })
@@ -272,7 +273,7 @@ class CreateFeed extends React.Component<AllProps, CreateFeedState> {
     do {
       const pluginsPage = await client.getPlugins({
         limit: 25,
-        offset: page * 25
+        offset: page * 25,
       });
       const plugins = pluginsPage.getItems();
       if (!plugins) {
@@ -298,12 +299,9 @@ class CreateFeed extends React.Component<AllProps, CreateFeedState> {
       if (this.state.data.localFiles.length > 0) {
         const local_upload_path = this.generateTempDirName();
         const files = await this.uploadLocalFiles(local_upload_path);
-        const flattenedPath = _.flattenDepth(files.map(file => file.data));
+        const flattenedPath = _.flattenDepth(files.map((file) => file.data));
 
-        dirPath = flattenedPath[0].fname
-          .split("/")
-          .slice(0, -1)
-          .join("/");
+        dirPath = flattenedPath[0].fname.split("/").slice(0, -1).join("/");
       }
       // Find dircopy plugin
       const dircopy = await this.getDircopyPlugin();
@@ -315,7 +313,7 @@ class CreateFeed extends React.Component<AllProps, CreateFeedState> {
       const dircopyInstances = await dircopy.getPluginInstances();
 
       await dircopyInstances.post({
-        dir: dirPath
+        dir: dirPath,
       });
 
       //when the `post` finishes, the dircopyInstances's internal collection is updated
@@ -335,7 +333,7 @@ class CreateFeed extends React.Component<AllProps, CreateFeedState> {
 
       // Set feed name
       await feed.put({
-        name: this.state.data.feedName
+        name: this.state.data.feedName,
       });
 
       // Set feed tags
@@ -348,7 +346,7 @@ class CreateFeed extends React.Component<AllProps, CreateFeedState> {
       await note.put(
         {
           title: "Description",
-          content: this.state.data.feedDescription
+          content: this.state.data.feedDescription,
         },
         1000
       );
@@ -374,7 +372,7 @@ class CreateFeed extends React.Component<AllProps, CreateFeedState> {
         comments: getLinkUrl("comments"),
         tags: getLinkUrl("tags"),
         taggings: getLinkUrl("taggings"),
-        plugin_instances: getLinkUrl("plugininstances")
+        plugin_instances: getLinkUrl("plugininstances"),
       };
 
       this.props.addFeed(feedObj);
@@ -429,22 +427,22 @@ class CreateFeed extends React.Component<AllProps, CreateFeedState> {
         id: 1, // id corresponds to step number
         name: "Basic Information",
         component: basicInformation,
-        enableNext: !!data.feedName
+        enableNext: !!data.feedName,
       },
       {
         name: "Data Configuration",
         steps: [
           { id: 2, name: "ChRIS File Select", component: chrisFileSelect },
-          { id: 3, name: "Local File Upload", component: localFileUpload }
-        ]
+          { id: 3, name: "Local File Upload", component: localFileUpload },
+        ],
       },
       {
         id: 4,
         name: "Review",
         component: review,
         enableNext: enableSave,
-        nextButtonText: "Save"
-      }
+        nextButtonText: "Save",
+      },
     ];
 
     return (
@@ -478,11 +476,11 @@ class CreateFeed extends React.Component<AllProps, CreateFeedState> {
 
 const mapStateToProps = (state: ApplicationState) => ({
   authToken: state.user.token || "",
-  feeds: state.feed.feeds
+  feeds: state.feed.feeds,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  addFeed: (feed: IFeedItem) => dispatch(addFeed(feed))
+  addFeed: (feed: IFeedItem) => dispatch(addFeed(feed)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(CreateFeed);

--- a/src/components/feed/ShareFeed/ShareFeed.tsx
+++ b/src/components/feed/ShareFeed/ShareFeed.tsx
@@ -20,7 +20,7 @@ class ShareFeed extends React.Component<ShareFeedProps, ShareFeedState> {
   constructor(props: ShareFeedProps) {
     super(props);
     this.state = {
-      showOverlay: false
+      showOverlay: false,
     };
     this.handleAddClick = this.handleAddClick.bind(this);
     this.handleModalClose = this.handleModalClose.bind(this);
@@ -28,14 +28,12 @@ class ShareFeed extends React.Component<ShareFeedProps, ShareFeedState> {
   }
 
   handleAddClick() {
-    this.setState(prevState => ({
-      showOverlay: !prevState.showOverlay
+    this.setState((prevState) => ({
+      showOverlay: !prevState.showOverlay,
     }));
   }
 
   async handleCreate(username: string) {
-    console.log("username", username);
-
     const { details } = this.props;
     if (!details) {
       return;
@@ -44,16 +42,15 @@ class ShareFeed extends React.Component<ShareFeedProps, ShareFeedState> {
     const client = ChrisAPIClient.getClient();
     const feed = await client.getFeed(id);
     const test = await feed.put({
-      owner: username
+      owner: username,
     });
-    console.log(test);
 
     this.handleModalClose();
   }
 
   handleModalClose() {
-    this.setState(prevState => ({
-      showOverlay: !prevState.showOverlay
+    this.setState((prevState) => ({
+      showOverlay: !prevState.showOverlay,
     }));
   }
 

--- a/src/components/feed/ShareFeed/ShareFeed.tsx
+++ b/src/components/feed/ShareFeed/ShareFeed.tsx
@@ -41,7 +41,7 @@ class ShareFeed extends React.Component<ShareFeedProps, ShareFeedState> {
     const id = details.id as number;
     const client = ChrisAPIClient.getClient();
     const feed = await client.getFeed(id);
-    const test = await feed.put({
+    await feed.put({
       owner: username,
     });
 

--- a/src/components/plugin/PluginDetailPanel.tsx
+++ b/src/components/plugin/PluginDetailPanel.tsx
@@ -6,7 +6,7 @@ import {
   DataList,
   DataListItem,
   DataListToggle,
-  DataListContent
+  DataListContent,
 } from "@patternfly/react-core";
 import { ApplicationState } from "../../store/root/applicationState";
 
@@ -15,7 +15,7 @@ import PluginConfiguration from "./PluginConfiguration";
 import PluginOutput from "./PluginOutput";
 import {
   getPluginInstanceTitle,
-  IPluginItem
+  IPluginItem,
 } from "../../api/models/pluginInstance.model";
 import "./plugin.scss";
 import { LoadingSpinner } from "..";
@@ -34,7 +34,7 @@ class PluginDetailPanel extends React.Component<IPluginProps, IState> {
   constructor(props: IPluginProps) {
     super(props);
     this.state = {
-      expanded: ["plugin-detail", "plugin-config", "plugin-data"]
+      expanded: ["plugin-detail", "plugin-config", "plugin-data"],
     };
     this.handleDownloadData = this.handleDownloadData.bind(this);
     this.handleViewData = this.handleViewData.bind(this);
@@ -53,7 +53,6 @@ class PluginDetailPanel extends React.Component<IPluginProps, IState> {
   }
 
   render() {
-    console.log("PluginDetailPanelCalled");
     // Note: Keep toggle of sub panels in local state
     const toggle = (id: string) => {
       const expanded = this.state.expanded;
@@ -62,7 +61,7 @@ class PluginDetailPanel extends React.Component<IPluginProps, IState> {
         index >= 0
           ? [
               ...expanded.slice(0, index),
-              ...expanded.slice(index + 1, expanded.length)
+              ...expanded.slice(index + 1, expanded.length),
             ]
           : [...expanded, id];
       this.setState(() => ({ expanded: newExpanded }));
@@ -178,7 +177,7 @@ class PluginDetailPanel extends React.Component<IPluginProps, IState> {
 const mapStateToProps = (state: ApplicationState) => ({
   selected: state.plugin.selected,
   files: getSelectedFiles(state),
-  parameters: state.plugin.parameters
+  parameters: state.plugin.parameters,
 });
 
 export default connect(mapStateToProps, null)(PluginDetailPanel);

--- a/src/components/viewer/OutputViewerContainer.tsx
+++ b/src/components/viewer/OutputViewerContainer.tsx
@@ -11,7 +11,7 @@ import {
   DataTableViewer,
   FreesurferDataTable,
   ZScoreDataTable,
-  FileBrowserViewer
+  FileBrowserViewer,
 } from "./displays/index";
 import VolumeGrowth from "../../components/chart/VolumeGrowth";
 import SegmentAnalysis from "../../components/chart/SegmentAnalysis";
@@ -34,7 +34,7 @@ class OutputViewerContainer extends React.Component<
   }
 
   state = {
-    activeTabKey: 0
+    activeTabKey: 0,
   };
 
   render() {
@@ -60,7 +60,7 @@ class OutputViewerContainer extends React.Component<
     tabIndex: React.ReactText
   ) => {
     this.setState({
-      activeTabKey: tabIndex as number
+      activeTabKey: tabIndex as number,
     });
   };
   // Description: Build Tabs from data
@@ -141,7 +141,7 @@ class OutputViewerContainer extends React.Component<
 
 const mapStateToProps = (state: ApplicationState) => ({
   files: getSelectedFiles(state),
-  selected: state.plugin.selected
+  selected: state.plugin.selected,
 });
 
 export default connect(mapStateToProps, null)(OutputViewerContainer);

--- a/src/components/viewer/displays/DicomViewer.tsx
+++ b/src/components/viewer/displays/DicomViewer.tsx
@@ -8,7 +8,7 @@ type AllProps = {
   pluginType?: string;
 };
 
-// Description: Will be replaced with a DCM Fyle viewer
+// Description: Will be replaced with a DCM File viewer
 const DicomViewer: React.FunctionComponent<AllProps> = (props: AllProps) => {
   const imageSrc =
     props.pluginType === "DicomViewer_3D"

--- a/src/components/viewer/displays/FreesurferDataTable.tsx
+++ b/src/components/viewer/displays/FreesurferDataTable.tsx
@@ -29,7 +29,7 @@ class FreesurferDataTable extends React.Component<AllProps> {
     this.rows = this.mergeData();
   }
   // Description: build table rows from json/ts file
-  // We need somev validation for this merge ***** working
+  // We need some validation for this merge ***** working
   mergeData = () => {
     const customizer = (objValue: any, srcValue: any) => {
       return [objValue, srcValue];


### PR DESCRIPTION
**In this PR:**

- Fixed the file-viewer for dicom images
- Add a display for files without built-in-viewers

Closes #88 

**Dicom file Viewer in the file-explorer**

![Fix_Container_width](https://user-images.githubusercontent.com/15992276/80644082-121dd200-8a37-11ea-8295-bb56ab9b34bd.png)

**Gallery for viewing dicom files**

![File_viewers](https://user-images.githubusercontent.com/15992276/80644080-121dd200-8a37-11ea-8211-06d3ab0d32ea.png)

**Adding an alert for files with unknown extensions**
![Unknown_file_type](https://user-images.githubusercontent.com/15992276/80644085-12b66880-8a37-11ea-8bb2-58c13d420a43.png)

**Things to do:**
1. Abstract repetitive code for the Ami file viewer.
2. Fixing types in the gallery which are sprinkled throughout the code.

