### PR TITLE
Feature/update feed tree

### DIFF
--- a/src/components/feed/FeedTree/FeedTree.tsx
+++ b/src/components/feed/FeedTree/FeedTree.tsx
@@ -11,16 +11,12 @@ import {
 } from "../../../store/feed/types";
 import { ApplicationState } from "../../../store/root/applicationState";
 import "./feedTree.scss";
-import {
-  getSelectedInstanceResource } from "../../../store/feed/selector";
-  
 
 
 interface ITreeProps {
   pluginInstances: PluginInstancePayload;
   selectedPlugin?: PluginInstance;
   pluginInstanceResource: ResourcePayload;
-  
 }
 
 interface OwnProps {
@@ -31,10 +27,8 @@ const FeedTree: React.FC<ITreeProps & OwnProps> = ({
   pluginInstances,
   selectedPlugin,
   pluginInstanceResource,
-  onNodeClick
+  onNodeClick,
 }) => {
-  const pluginStatus =
-    pluginInstanceResource && pluginInstanceResource.pluginStatus;
   const treeRef = useRef<HTMLDivElement>(null);
   const svgRef = useRef<SVGSVGElement>(null);
   const { data: instances, error, loading } = pluginInstances;
@@ -224,7 +218,7 @@ const FeedTree: React.FC<ITreeProps & OwnProps> = ({
     if (instances && instances.length > 0) {
       buildTree(instances);
     }
-  }, [instances, selectedPlugin, buildTree, pluginStatus]);
+  }, [instances, selectedPlugin, buildTree, pluginInstanceResource]);
 
   if (!selectedPlugin || !selectedPlugin.data) {
     return (
@@ -261,7 +255,7 @@ const FeedTree: React.FC<ITreeProps & OwnProps> = ({
 
 
 const mapStateToProps = (state: ApplicationState) => ({
-  pluginInstanceResource: getSelectedInstanceResource(state),
+  pluginInstanceResource: state.feed.pluginInstanceResource,
   pluginInstances: state.feed.pluginInstances,
   selectedPlugin: state.feed.selectedPlugin,
 });

--- a/src/components/feed/FeedTree/feedTree.scss
+++ b/src/components/feed/FeedTree/feedTree.scss
@@ -28,9 +28,9 @@
 }
 
  @keyframes active{
-     0%    { fill:#73BCF7; }
-    50%   { fill: black; }
-    100%  { fill: #73BCF7; }
+     0%    { fill:#0088ce; }
+    50%   { fill: #7dc3e8; }
+    100%  { fill: #0088ce; }
  }
 
  @keyframes error {
@@ -51,12 +51,7 @@
   cursor: pointer;
 
     &.queued {
-    animation-name:queued;
-    animation-duration:2s;
-    animation-timing-function:ease-in;
-    animation-iteration-count:3;
-    animation-delay:1s;
-    animation-fill-mode:both;
+    fill: #aaa;
    
     .label {
       fill: #aaa;
@@ -66,7 +61,7 @@
     &.success{
     fill:#004080;
     .label {
-      fill: #0066CC;
+      fill:#004080; ;
     }
    }
 

--- a/src/components/feed/NodeDetails/NodeDetails.scss
+++ b/src/components/feed/NodeDetails/NodeDetails.scss
@@ -37,13 +37,12 @@
         font-size: $plugin-data-font-size;
         margin-bottom: 0.5rem;
         text-align: left;
-        outline-color: #fff;
+        
         svg {
           margin-right: 5px;
         }
         &:hover,
         &:focus {
-          background: #fff;
           color: $node-block-background;
           &::after {
             border-color: #fff;

--- a/src/components/feed/NodeDetails/NodeDetails.tsx
+++ b/src/components/feed/NodeDetails/NodeDetails.tsx
@@ -386,18 +386,17 @@ function getCommand(
       }
     }
 
-    let command = `docker run --rm -v $(pwd)/in:/incoming -v $(pwd)/out:/outgoing ${dock_image} ${selfexec}`;
-    if (modifiedParams.length) {
-      command +=
-        "\n" + modifiedParams.map((param) => `${param.name} ${param.value}`);
-    }
-    command = `${command}\n /incoming/outgoing`.trim();
-    const lines = command.split("\n");
-    const longest = lines.reduce((a, b) => (a.length > b.length ? a : b))
-      .length;
-    return lines
-      .map((line) => `${line.padEnd(longest)} \\`)
-      .join("\n")
-      .slice(0, -1);
+    let command = `docker run --rm \\\n -v $(pwd)/in:/incoming \\\n -v $(pwd)/out:/outgoing \\\n ${dock_image} \\\n ${selfexec} \\\n`;
+    let parameterCommand=[]
     
+    
+    if (modifiedParams.length) {
+      parameterCommand=modifiedParams.map((param) => `${param.name} ${param.value}`);
+      if(parameterCommand.length>0){
+        command+=parameterCommand.join(' ') + ' \\\n'
+      }
+    }
+    command = `${command} /incoming/outgoing`.trim();
+  
+    return command;
 }

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -35,7 +35,7 @@ class DashboardPage extends React.Component<AllProps> {
         <Badge key={3}>
           <span>
             Latest update:{" "}
-            <Moment format="DD MMM YYYY @ HH:mm">{`2020-12-18T13:30:14.297464-04:00`}</Moment>
+            <Moment format="DD MMM YYYY @ HH:mm">{`2020-12-23T16:00:14.297464-04:00`}</Moment>
           </span>
         </Badge>
       </>

--- a/src/store/feed/saga.ts
+++ b/src/store/feed/saga.ts
@@ -192,7 +192,7 @@ function* handleGetPluginStatus(
         yield call(fetchPluginFiles, instance);
         yield put(stopFetchingPluginResources(instance.data.id));
       } else {
-        yield delay(3000);
+        yield delay(7000);
       }
     } catch (error) {
       yield put(stopFetchingPluginResources(instance.data.id));


### PR DESCRIPTION
In this PR:

1. Update to the Feed Tree where only the active node pulses.
2. Update to the format of the command in the 'view command' popover
3. Increase the polling time to change plugin execution statuses to 7 seconds.