### PR TITLE
Bugfix/consistent design for file previews

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@fnndsc/chrisapi": "^1.5.0",
     "@patternfly/patternfly": "^4.87.3",
-    "@patternfly/react-core": "^4.97.2",
+    "@patternfly/react-core": "^4.106.2",
     "@patternfly/react-icons": "^4.9.2",
     "@patternfly/react-styles": "^4.8.2",
     "@patternfly/react-table": "^4.23.2",

--- a/src/components/detailedView/DetailedViewerContainer.tsx
+++ b/src/components/detailedView/DetailedViewerContainer.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useTypedSelector } from "../../store/hooks";
 import { Tabs, Tab, Alert } from "@patternfly/react-core";
 import { FileBrowserViewer } from "./displays";
-import "./viewer.scss";
+import "./Viewer.scss";
 
 const OutputViewerContainer = () => {
   const { pluginFiles, selectedPlugin } = useTypedSelector(
@@ -12,7 +12,7 @@ const OutputViewerContainer = () => {
   const [activeTabKey, setActiveTabKey] = React.useState(0);
 
   if (!selectedPlugin || !pluginFiles) {
-    return <Alert variant="info" title="Empty Result Set" className="empty" />;
+   return <Alert variant="info" title="Empty Result Set" className="empty" />;
   } else {
     const buildTabs = () => {
       const tabs = [];

--- a/src/components/detailedView/PluginViewerModal.tsx
+++ b/src/components/detailedView/PluginViewerModal.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import { Modal } from "@patternfly/react-core";
-import { Gotop } from "../../index";
+import { Modal, Skeleton } from "@patternfly/react-core";
+import Gotop from "../common/gotop/Gotop";
 
 const OutputViewerContainer = React.lazy(
-  () => import("../../detailedView/DetailedViewerContainer")
+  () => import("./DetailedViewerContainer")
 );
 
 type AllProps = {
@@ -42,9 +42,13 @@ const PluginViewerModal = (props: AllProps) => {
         onScroll={handleScroll}
         onClose={() => handleModalToggle()}
       >
-        <React.Suspense fallback={
-          <div>Fetching Resources....</div>
-        }>
+        <React.Suspense
+          fallback={
+            <div style={{ height: "100vh" }}>
+              <Skeleton height="100%" screenreaderText="Fetching Resources" />
+            </div>
+          }
+        >
           <OutputViewerContainer />
         </React.Suspense>
 

--- a/src/components/detailedView/Viewer.scss
+++ b/src/components/detailedView/Viewer.scss
@@ -1,5 +1,5 @@
 /*
-*  File:            viewer.scss
+*  File:            Viewer.scss
 *  Description:     This files holds styles specific for the output viewer components
 *  Author:          ChRIS UI
 */
@@ -14,7 +14,7 @@
     margin-left: 2rem;
   }
   .output-viewer {
-    min-height: 50vh;
+    height:80%;
     min-width: 80vw;
 
     .pf-c-tabs {
@@ -100,5 +100,8 @@
 
 
 .large-preview {
-  height: 100%;
+  //height: 100%;
+  height:90%;
+
+ 
 }

--- a/src/components/detailedView/displays/FileBrowserViewer.tsx
+++ b/src/components/detailedView/displays/FileBrowserViewer.tsx
@@ -40,7 +40,6 @@ const FileBrowserViewer = () => {
                 return <BreadcrumbItem key={index}>{item}</BreadcrumbItem>;
               })}
             </Breadcrumb>
-
             <Tree
               defaultExpandedKeys={selectedKeys}
               selectedKeys={selectedKeys}
@@ -49,7 +48,7 @@ const FileBrowserViewer = () => {
               showLine
             />
           </GridItem>
-          <GridItem  sm={12} md={8}>
+          <GridItem sm={12} md={8}>
             {selectedFile && selectedFile.file && (
               <FileDetailView
                 selectedFile={selectedFile.file}
@@ -59,9 +58,7 @@ const FileBrowserViewer = () => {
           </GridItem>
         </Grid>
       ) : (
-        <div className="viewer-data">
-          <GalleryDicomView />
-        </div>
+        <GalleryDicomView />
       )}
     </div>
   );

--- a/src/components/dicomViewer/amiViewer.scss
+++ b/src/components/dicomViewer/amiViewer.scss
@@ -18,7 +18,20 @@
     width: 100%;
     font-size: 0.7rem;
   }
+<<<<<<< HEAD
 
+=======
+  .iframe-container {
+    position:absolute;
+    width:100%;
+    height: 100%;
+  
+    iframe {
+      height: 100% !important;
+    }
+  }
+  
+>>>>>>> Fixed the inconsistency in file previews across all file formats
 }
 
 @media(min-width:1020px){

--- a/src/components/dicomViewer/amiViewer.scss
+++ b/src/components/dicomViewer/amiViewer.scss
@@ -18,9 +18,6 @@
     width: 100%;
     font-size: 0.7rem;
   }
-<<<<<<< HEAD
-
-=======
   .iframe-container {
     position:absolute;
     width:100%;
@@ -31,7 +28,6 @@
     }
   }
   
->>>>>>> Fixed the inconsistency in file previews across all file formats
 }
 
 @media(min-width:1020px){

--- a/src/components/feed/FeedOutputBrowser/FeedOutputBrowser.scss
+++ b/src/components/feed/FeedOutputBrowser/FeedOutputBrowser.scss
@@ -18,18 +18,9 @@
   .ant-tree {
     background-color: inherit !important;
   }
-
-  &__sidebar {
-    width: 100%;
-  }
-
-  &__main {
-    width: 100%;
-  }
 }
 
 .file-browser {
-
   height: 100%;
   &__downloadButton {
     max-width: 50% !important;
@@ -43,8 +34,9 @@
   }
 
   &__table {
+    padding-right: 0 !important;
     &--fileName {
-      display:flex;
+      display: flex;
       flex-direction: row;
       border: 1px solid transparent;
       border-radius: 5px;
@@ -72,8 +64,6 @@
       }
     }
   }
-
-
 
   &__header {
     display: flex;
@@ -120,42 +110,27 @@
     }
   }
 
-  &__grid2 {
-    .header-panel__buttons {
-      display: flex;
-      justify-content: space-between;
-      margin-bottom: 0.25em;
-      margin-right: 0.25em;
+  .header-panel__buttons {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 0.25em;
+    margin-right: 0.25em;
 
-      button {
-        padding-top: 0;
-      }
+    button {
+      padding-top: 0;
     }
   }
 
   .small-preview {
-   
-    @include media-query(1200px) {
-      height: 300px;
+    height: 90%;
+    img {
+      height: 100%;
     }
-
-    @include media-query(1920px) {
-      height: 500px;
-    }
-
-    width: 100%;
   }
 
   .dcm-preview {
     position: relative;
-
-    @include media-query(1200px) {
-      min-height: 300px;
-    }
-
-    @include media-query(1920px) {
-      min-height: 500px;
-    }
+    height: 100%;
 
     #container {
       bottom: 0;

--- a/src/components/feed/FeedOutputBrowser/FeedOutputBrowser.scss
+++ b/src/components/feed/FeedOutputBrowser/FeedOutputBrowser.scss
@@ -29,6 +29,7 @@
 }
 
 .file-browser {
+
   height: 100%;
   &__downloadButton {
     max-width: 50% !important;
@@ -43,6 +44,8 @@
 
   &__table {
     &--fileName {
+      display:flex;
+      flex-direction: row;
       border: 1px solid transparent;
       border-radius: 5px;
       outline: none;
@@ -50,6 +53,15 @@
       font-family: var(
         --pf-global--FontFamily--redhatfont--sans-serif
       ) !important;
+    }
+
+    tr > *:first-child {
+      padding: 0;
+      text-align: right;
+    }
+
+    .pf-m-truncate {
+      padding-left: 0 !important;
     }
 
     &--isPreviewing {
@@ -60,6 +72,8 @@
       }
     }
   }
+
+
 
   &__header {
     display: flex;

--- a/src/components/feed/FeedOutputBrowser/FeedOutputBrowser.tsx
+++ b/src/components/feed/FeedOutputBrowser/FeedOutputBrowser.tsx
@@ -44,11 +44,11 @@ const FeedOutputBrowser: React.FC<FeedOutputBrowserProps> = ({
   const [pluginModalOpen, setPluginModalOpen] = React.useState(false);
   const dispatch = useDispatch();
   const safeDispatch = useSafeDispatch(dispatch);
-  const {
-    selectedPlugin: selected,
-    pluginFiles,
-    pluginInstances,
-  } = useTypedSelector((state) => state.feed);
+  const selected = useTypedSelector((state) => state.feed.selectedPlugin);
+  const pluginFiles = useTypedSelector((state) => state.feed.pluginFiles);
+  const pluginInstances = useTypedSelector(
+    (state) => state.feed.pluginInstances
+  );
   const viewerMode = useTypedSelector((state) => state.explorer.viewerMode);
   const currentFeed = useTypedSelector((state) => state.feed.currentFeed.data);
   const { data: plugins, loading } = pluginInstances;
@@ -59,11 +59,10 @@ const FeedOutputBrowser: React.FC<FeedOutputBrowserProps> = ({
       safeDispatch(getPluginFilesRequest(selected));
     }
   }, [selected, pluginFilesPayload, safeDispatch]);
-
   if (!selected || isEmpty(pluginInstances) || loading) {
     return <LoadingFeedBrowser />;
   } else {
-    const pluginName = selected && getPluginName(selected);
+    const pluginName = getPluginName(selected);
     const pluginFiles = pluginFilesPayload && pluginFilesPayload.files;
     const tree: DataNode[] | null = createTreeFromFiles(selected, pluginFiles);
     const downloadAllClick = async () => {
@@ -106,8 +105,6 @@ const FeedOutputBrowser: React.FC<FeedOutputBrowserProps> = ({
       //@ts-ignore
       selected.data.output_path.split(`feed_${currentFeed.data.id}/`)[1];
     const breadcrumb = splitPath.split("/data")[0];
-    
-    
 
     return (
       <>
@@ -194,7 +191,7 @@ const FeedOutputBrowser: React.FC<FeedOutputBrowserProps> = ({
   }
 };
 
-export default FeedOutputBrowser;
+export default React.memo(FeedOutputBrowser);
 
 /**
  * Utility Components

--- a/src/components/feed/FeedOutputBrowser/FeedOutputBrowser.tsx
+++ b/src/components/feed/FeedOutputBrowser/FeedOutputBrowser.tsx
@@ -62,14 +62,12 @@ const FeedOutputBrowser: React.FC<FeedOutputBrowserProps> = ({
   if (!selected || isEmpty(pluginInstances) || loading) {
     return <LoadingFeedBrowser />;
   } else {
-    const pluginName = selected && selected.data && getPluginName(selected);
+    const pluginName = selected && getPluginName(selected);
     const pluginFiles = pluginFilesPayload && pluginFilesPayload.files;
     const tree: DataNode[] | null = createTreeFromFiles(selected, pluginFiles);
     //@ts-ignore
     const breadcrumb = selected.data.output_path.split("/");
     const downloadAllClick = async () => {
-      if (!selected) return;
-
       const zip = new JSZip();
       if (pluginFiles) {
         for (const file of pluginFiles) {

--- a/src/components/feed/FeedOutputBrowser/FeedOutputBrowser.tsx
+++ b/src/components/feed/FeedOutputBrowser/FeedOutputBrowser.tsx
@@ -14,7 +14,7 @@ import {
 } from "@patternfly/react-core";
 import { CubeIcon } from "@patternfly/react-icons";
 import { Spin, Alert, Tree } from "antd";
-import PluginViewerModal from "./PluginViewerModal";
+import PluginViewerModal from "../../detailedView/PluginViewerModal";
 import {
   setExplorerRequest,
   toggleViewerMode,
@@ -50,6 +50,7 @@ const FeedOutputBrowser: React.FC<FeedOutputBrowserProps> = ({
     pluginInstances,
   } = useTypedSelector((state) => state.feed);
   const viewerMode = useTypedSelector((state) => state.explorer.viewerMode);
+  const currentFeed = useTypedSelector((state) => state.feed.currentFeed.data);
   const { data: plugins, loading } = pluginInstances;
   const pluginFilesPayload = selected && pluginFiles[selected.data.id];
 
@@ -65,8 +66,6 @@ const FeedOutputBrowser: React.FC<FeedOutputBrowserProps> = ({
     const pluginName = selected && getPluginName(selected);
     const pluginFiles = pluginFilesPayload && pluginFilesPayload.files;
     const tree: DataNode[] | null = createTreeFromFiles(selected, pluginFiles);
-    //@ts-ignore
-    const breadcrumb = selected.data.output_path.split("/");
     const downloadAllClick = async () => {
       const zip = new JSZip();
       if (pluginFiles) {
@@ -102,6 +101,14 @@ const FeedOutputBrowser: React.FC<FeedOutputBrowserProps> = ({
       pluginSidebarTree = getFeedTree(plugins);
     }
 
+    const splitPath =
+      currentFeed &&
+      //@ts-ignore
+      selected.data.output_path.split(`feed_${currentFeed.data.id}/`)[1];
+    const breadcrumb = splitPath.split("/data")[0];
+    
+    
+
     return (
       <>
         <Grid hasGutter className="feed-output-browser ">
@@ -120,7 +127,6 @@ const FeedOutputBrowser: React.FC<FeedOutputBrowserProps> = ({
           >
             {pluginSidebarTree && (
               <DirectoryTree
-                multiple
                 defaultExpandAll
                 defaultExpandedKeys={[selected.data.id]}
                 treeData={pluginSidebarTree}
@@ -168,10 +174,7 @@ const FeedOutputBrowser: React.FC<FeedOutputBrowserProps> = ({
                   handleFileViewerToggle={handleFileViewerOpen}
                   downloadAllClick={downloadAllClick}
                   expandDrawer={expandDrawer}
-                  breadcrumb={[
-                    ...breadcrumb.slice(0, breadcrumb.length - 1),
-                    "",
-                  ]}
+                  breadcrumb={[...breadcrumb.split("/"), ""]}
                 />
               </React.Suspense>
             ) : selected.data.status === "cancelled" ||

--- a/src/components/feed/FeedOutputBrowser/FileBrowser.tsx
+++ b/src/components/feed/FeedOutputBrowser/FileBrowser.tsx
@@ -30,7 +30,9 @@ import {
   Table,
   TableHeader,
   TableBody,
-  TableVariant,
+  cellWidth,
+  truncate,
+  TableText,
 } from "@patternfly/react-table";
 import FileViewerModel from "../../../api/models/file-viewer.model";
 import { FileBrowserProps, FileBrowserState } from "./types";
@@ -149,16 +151,26 @@ const FileBrowser = (props: FileBrowserProps) => {
     }
     const icon = getIcon(type);
     const isPreviewing = selectedFile && selectedFile.key === node.key;
+    const iconRow = {
+      title: icon,
+    };
     const fileName = (
       <div
-        className={classNames(
-          "file-browser__table--fileName",
-          isPreviewing && "file-browser__table--isPreviewing"
-        )}
+      className={classNames(
+        "file-browser__table--fileName",
+        isPreviewing && "file-browser__table--isPreviewing"
+      )}
       >
-        {icon}
+         <TableText
+        wrapModifier="truncate"
+      
+      >
+        {" "}
         {node.title}
+      </TableText>
+
       </div>
+     
     );
     const name = {
       title: fileName,
@@ -178,11 +190,18 @@ const FileBrowser = (props: FileBrowserProps) => {
     };
 
     return {
-      cells: [name, type, size, download],
+      cells: [iconRow, name, type, size, download],
     };
   };
 
-  const cols = ["Name", "Type", "Size", ""];
+  const cols = [
+    { title: "" },
+    { title: "Name", transforms: [cellWidth(55)], cellTransforms: [truncate] },
+    { title: "Type" },
+    { title: "Size" },
+    { title: "" },
+  ];
+
   if (!directory || directory.children.length === 0) {
     return <div>No Files in this directory.</div>;
   }
@@ -275,8 +294,8 @@ const FileBrowser = (props: FileBrowserProps) => {
 
               <Table
                 className="file-browser__table"
-                aria-label="file-browser"
-                variant={TableVariant.compact}
+                aria-label="file-browser-table"
+                variant="compact"
                 cells={cols}
                 rows={rows}
               >

--- a/src/components/feed/FeedOutputBrowser/FileBrowser.tsx
+++ b/src/components/feed/FeedOutputBrowser/FileBrowser.tsx
@@ -156,21 +156,13 @@ const FileBrowser = (props: FileBrowserProps) => {
     };
     const fileName = (
       <div
-      className={classNames(
-        "file-browser__table--fileName",
-        isPreviewing && "file-browser__table--isPreviewing"
-      )}
+        className={classNames(
+          "file-browser__table--fileName",
+          isPreviewing && "file-browser__table--isPreviewing"
+        )}
       >
-         <TableText
-        wrapModifier="truncate"
-      
-      >
-        {" "}
-        {node.title}
-      </TableText>
-
+        <TableText wrapModifier="truncate"> {node.title}</TableText>
       </div>
-     
     );
     const name = {
       title: fileName,
@@ -196,7 +188,7 @@ const FileBrowser = (props: FileBrowserProps) => {
 
   const cols = [
     { title: "" },
-    { title: "Name", transforms: [cellWidth(55)], cellTransforms: [truncate] },
+    { title: "Name", transforms: [cellWidth(40)], cellTransforms: [truncate] },
     { title: "Type" },
     { title: "Size" },
     { title: "" },
@@ -214,19 +206,7 @@ const FileBrowser = (props: FileBrowserProps) => {
     getFileExtension(selectedFile.file.data.fname);
 
   const previewPanel = (
-    <GridItem
-      xl2={8}
-      xl2RowSpan={12}
-      xl={8}
-      xlRowSpan={12}
-      lg={8}
-      lgRowSpan={12}
-      md={8}
-      mdRowSpan={12}
-      sm={12}
-      smRowSpan={12}
-      className="file-browser__grid2"
-    >
+    <>
       {renderHeaderPanel(
         handleFileViewerToggle,
         handleFileBrowserToggle,
@@ -237,7 +217,7 @@ const FileBrowser = (props: FileBrowserProps) => {
       {selectedFile && selectedFile.file && (
         <FileDetailView selectedFile={selectedFile.file} preview="small" />
       )}
-    </GridItem>
+    </>
   );
 
   return (
@@ -266,7 +246,7 @@ const FileBrowser = (props: FileBrowserProps) => {
             >
               <div className="file-browser__header">
                 <div className="file-browser__header--breadcrumbContainer">
-                  <Breadcrumb>
+                <Breadcrumb>
                     {breadcrumb.map((value: string, index: number) => {
                       return (
                         <BreadcrumbItem key={index}>{value}</BreadcrumbItem>

--- a/src/components/feed/FeedOutputBrowser/utils/index.ts
+++ b/src/components/feed/FeedOutputBrowser/utils/index.ts
@@ -10,6 +10,7 @@ export function createTreeFromFiles(
   files?: FeedFile[]
 ): DataNode[] | null {
   if (!files || !selected) return null;
+  console.log("Tree algo called");
   const filePaths = files.map((file) => {
     const filePath = file.data.fname.substring(
       file.data.fname.lastIndexOf(

--- a/src/components/feed/FeedOutputBrowser/utils/index.ts
+++ b/src/components/feed/FeedOutputBrowser/utils/index.ts
@@ -10,7 +10,7 @@ export function createTreeFromFiles(
   files?: FeedFile[]
 ): DataNode[] | null {
   if (!files || !selected) return null;
-  console.log("Tree algo called");
+
   const filePaths = files.map((file) => {
     const filePath = file.data.fname.substring(
       file.data.fname.lastIndexOf(

--- a/src/components/feed/FeedOutputBrowser/utils/index.ts
+++ b/src/components/feed/FeedOutputBrowser/utils/index.ts
@@ -17,7 +17,7 @@ export function createTreeFromFiles(
       ),
       file.data.fname.length
     );
-    //@ts-ignores
+    //@ts-ignore
     const fileSize = bytesToSize(file.data.fsize);
     return {
       file: file,
@@ -62,7 +62,7 @@ const buildTree = (
     const pathParts = fileObj.filePath.split("/");
     pathParts.shift();
     let currentLevel = tree;
-    _.each(pathParts, function (part, index) {
+    _.each(pathParts, function (part) {
       const existingPath = _.find(currentLevel, {
         title: part,
       });
@@ -70,7 +70,7 @@ const buildTree = (
         currentLevel = existingPath.children;
       } else {
         const newPart = {
-          key: `${part}_${index}`,
+          key: `${part}_${fileObj.file.data.id}`,
           title: part,
           file: fileObj.file,
           fileSize: fileObj.fileSize,

--- a/src/components/feed/FeedTree/ParentComponent.tsx
+++ b/src/components/feed/FeedTree/ParentComponent.tsx
@@ -1,19 +1,14 @@
 import React from "react";
-import { connect } from "react-redux";
-import { Dispatch } from "redux";
+import { useDispatch } from "react-redux";
+import { useTypedSelector } from "../../../store/hooks";
 import { Spinner } from "@patternfly/react-core";
-import { ApplicationState } from "../../../store/root/applicationState";
-import { PluginInstancePayload, FeedTreeProp } from "../../../store/feed/types";
 import { setFeedTreeProp } from "../../../store/feed/actions";
 import { PluginInstance } from "@fnndsc/chrisapi";
 import FeedTree from "./FeedTree";
 import { getFeedTree, TreeNodeDatum } from "./data";
 
 interface ParentComponentProps {
-  pluginInstances: PluginInstancePayload;
   onNodeClick: (node: PluginInstance) => void;
-  feedTreeProp: FeedTreeProp;
-  setFeedTreeProp: (orientation: string) => void;
   isSidePanelExpanded: boolean;
   isBottomPanelExpanded: boolean;
   onExpand: (panel: string) => void;
@@ -22,15 +17,18 @@ interface ParentComponentProps {
 const ParentComponent = (props: ParentComponentProps) => {
   const {
     onNodeClick,
-    pluginInstances,
-    feedTreeProp,
-    setFeedTreeProp,
     isSidePanelExpanded,
     isBottomPanelExpanded,
     onExpand,
   } = props;
+
+  const pluginInstances = useTypedSelector(
+    (state) => state.feed.pluginInstances
+  );
+  const feedTreeProp = useTypedSelector((state) => state.feed.feedTreeProp);
   const { data: instances } = pluginInstances;
   const [data, setData] = React.useState<TreeNodeDatum[]>([]);
+  const dispatch = useDispatch();
 
   React.useEffect(() => {
     if (instances && instances.length > 0) {
@@ -40,7 +38,7 @@ const ParentComponent = (props: ParentComponentProps) => {
   }, [instances]);
 
   const changeOrientation = (orientation: string) => {
-    setFeedTreeProp(orientation);
+    dispatch(setFeedTreeProp(orientation));
   };
 
   return data && data.length > 0 ? (
@@ -72,14 +70,4 @@ const ParentComponent = (props: ParentComponentProps) => {
   );
 };
 
-const mapStateToProps = (state: ApplicationState) => ({
-  pluginInstances: state.feed.pluginInstances,
-  feedTreeProp: state.feed.feedTreeProp,
-});
-
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-  setFeedTreeProp: (orientation: string) =>
-    dispatch(setFeedTreeProp(orientation)),
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(ParentComponent);
+export default ParentComponent;

--- a/src/components/feed/NodeDetails/NodeDetails.tsx
+++ b/src/components/feed/NodeDetails/NodeDetails.tsx
@@ -52,7 +52,7 @@ function getInitialState() {
 
 const NodeDetails: React.FC<INodeProps> = ({ expandDrawer }) => {
   const [nodeState, setNodeState] = React.useState<INodeState>(getInitialState);
-  const { selectedPlugin } = useTypedSelector((state) => state.feed);
+  const selectedPlugin = useTypedSelector((state) => state.feed.selectedPlugin);
 
   const dispatch = useDispatch();
   const { plugin, instanceParameters, pluginParameters } = nodeState;

--- a/src/components/feed/Preview/FileDetailView.tsx
+++ b/src/components/feed/Preview/FileDetailView.tsx
@@ -79,9 +79,7 @@ const FileDetailView = (props: AllProps) => {
             </span>
           }
         >
-          <div
-            className={preview === "small" ? "small-preview" : "large-preview"}
-          >
+          <div className={preview === "small" ? "small-preview" : "ami-viewer"}>
             <ViewerDisplay viewerName={viewerName} fileItem={fileState} />
           </div>
         </ErrorBoundary>

--- a/src/containers/Layout/Header.tsx
+++ b/src/containers/Layout/Header.tsx
@@ -43,12 +43,12 @@ class Header extends React.Component<IHeaderProps> {
       <React.Fragment>
         <Brand src={brandImg} alt="ChRIS Logo" />
         <Badge key={4} style={BadgeStyle}>
-          <span>Version: 1.3.9</span>
+          <span>Version: 1.4.0</span>
         </Badge>
         <Badge key={3} style={BadgeStyle}>
           <span>
             Latest update:{" "}
-            <Moment format="DD MMM YYYY @ HH:mm">{`2021-04-08T17:00:10.297464-04:00`}</Moment>
+            <Moment format="DD MMM YYYY @ HH:mm">{`2021-04-14T20:30:10.297464-04:00`}</Moment>
           </span>
         </Badge>
       </React.Fragment>

--- a/src/pages/Feeds/components/FeedView.tsx
+++ b/src/pages/Feeds/components/FeedView.tsx
@@ -54,8 +54,6 @@ export const FeedView: React.FC<FeedViewProps> = ({match: { params: { id } } }: 
     selectedPlugin,
   };
 
-  console.log("Feed View:");
-
   React.useEffect(() => {
     return () => {
       if (dataRef.current) dispatch(destroyPluginState(dataRef.current));

--- a/src/pages/Feeds/components/FeedView.tsx
+++ b/src/pages/Feeds/components/FeedView.tsx
@@ -40,10 +40,12 @@ export type FeedViewProps = RouteComponentProps<{ id: string }>;
 export const FeedView: React.FC<FeedViewProps> = ({match: { params: { id } } }: FeedViewProps) => {
   const [isSidePanelExpanded, setSidePanelExpanded] = React.useState(true);
   const [isBottomPanelExpanded, setBottomPanelExpanded] = React.useState(true);
-  const { pluginInstances, selectedPlugin, currentLayout } = useTypedSelector(
-    (state) => state.feed
+  const selectedPlugin = useTypedSelector((state) => state.feed.selectedPlugin);
+  const currentLayout = useTypedSelector((state) => state.feed.currentLayout);
+  const pluginInstances = useTypedSelector(
+    (state) => state.feed.pluginInstances
   );
-  const dispatch=useDispatch();
+  const dispatch = useDispatch();
   const dataRef = React.useRef<DestroyData>();
   const { data } = pluginInstances;
 
@@ -51,22 +53,24 @@ export const FeedView: React.FC<FeedViewProps> = ({match: { params: { id } } }: 
     data,
     selectedPlugin,
   };
-  
+
+  console.log("Feed View:");
 
   React.useEffect(() => {
     return () => {
-      if(dataRef.current)
-      dispatch(destroyPluginState(dataRef.current));
+      if (dataRef.current) dispatch(destroyPluginState(dataRef.current));
       dispatch(destroyExplorer());
     };
   }, [dispatch]);
 
   React.useEffect(() => {
     document.title = "My Feeds - ChRIS UI site";
-    dispatch(setSidebarActive({
-      activeGroup: "feeds_grp",
-      activeItem: "my_feeds",
-    }));
+    dispatch(
+      setSidebarActive({
+        activeGroup: "feeds_grp",
+        activeItem: "my_feeds",
+      })
+    );
     dispatch(getFeedRequest(id));
   }, [id, dispatch]);
 


### PR DESCRIPTION
Closes #227 
- [x]  Fixed the inconsistencies in the preview screen across different file formats.
- [x] Reduced unnecessary renders in the file browser and the feed tree.
- [x] Added a 'truncate' transform to the cell in the file browser table with long file names.
- [x] Fixed a bug in the tree view regarding duplicate keys.



