### PR TITLE
Fixed a typo in the feed list table.

### DIFF
--- a/src/containers/Layout/Toolbar.tsx
+++ b/src/containers/Layout/Toolbar.tsx
@@ -33,15 +33,19 @@ const ToolbarComponent: React.FC<AllProps> = (props: AllProps) => {
     onDropdownSelect(isOpened);
   };
 
+  /*
+
   const onDropdownSelect = () => {
     const { onDropdownSelect, isDropdownOpen } = props;
     !!isDropdownOpen && onDropdownSelect(!isDropdownOpen); // NOTES: Toggle menu ****** to be determined, depending on actions (duplicate call for right now - stub)
   };
 
+  */
+
   // Description: Logout user
   const onLogout = () => {
     ChrisAPIClient.setIsTokenAuthorized(false);
-    props.setUserLogout();
+    setUserLogout();
   }
 
     const userDropdownItems = [

--- a/src/pages/Feeds/components/FeedListView.tsx
+++ b/src/pages/Feeds/components/FeedListView.tsx
@@ -120,7 +120,7 @@ const FeedListView: React.FC<AllProps> = ({
     "Feed",
     "Created",
     "Last Commit",
-    "Job Running",
+    "Jobs Running",
     "Jobs Done",
     "Errors",
     "",


### PR DESCRIPTION
Fix the typo  in 'Job Running' to 'Jobs Running'.

Before:
![Job_Running](https://user-images.githubusercontent.com/15992276/114879910-9ba4ec00-9dcf-11eb-97a3-9a77b928dafe.png)

After:
![Jobs_Running](https://user-images.githubusercontent.com/15992276/114879941-9fd10980-9dcf-11eb-94d2-497a5bf1d21e.png)


