### PR TITLE
fix toggle of panels when displaying feed graph #228

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 BROWSER=chrome
-REACT_APP_CHRIS_UI_URL="http://localhost:8000/api/v1/"
+REACT_APP_CHRIS_UI_URL="https://cube.outreachy.chrisproject.org/api/v1/"
 REACT_APP_CHRIS_UI_USERS_URL="${REACT_APP_CHRIS_UI_URL}users/"
 REACT_APP_CHRIS_UI_AUTH_URL="${REACT_APP_CHRIS_UI_URL}auth-token/"

--- a/src/components/feed/FeedTree/FeedGraph.tsx
+++ b/src/components/feed/FeedTree/FeedGraph.tsx
@@ -9,13 +9,16 @@ import {PluginInstance} from '@fnndsc/chrisapi'
 import {ErrorBoundary} from "react-error-boundary";
 import {Text} from '@patternfly/react-core'
 import './FeedTree.scss';
-
+import { Button } from "@patternfly/react-core";
 
 
 interface IFeedProps {
   pluginInstances: PluginInstancePayload;
   selectedPlugin?: PluginInstance;
   onNodeClick: (node: PluginInstance) => void;
+  isSidePanelExpanded: boolean;
+  isBottomPanelExpanded: boolean;
+  onExpand: (panel: string) => void;
 }
 
 
@@ -32,7 +35,7 @@ const useSize=(target:MutableRefObject<HTMLDivElement | null>)=>{
 }
 
 const FeedGraph = (props: IFeedProps) => {
-  const { pluginInstances, selectedPlugin, onNodeClick } = props;
+  const { pluginInstances, selectedPlugin, onNodeClick, isSidePanelExpanded, isBottomPanelExpanded, onExpand } = props;
   const { data: instances } = pluginInstances;
   const graphRef = React.useRef<HTMLDivElement | null>(null);
   const fgRef = React.useRef<ForceGraphMethods | undefined>();
@@ -81,6 +84,18 @@ const FeedGraph = (props: IFeedProps) => {
             </Text>
           }
         >
+          {!isSidePanelExpanded && (
+            <div className="feed-tree__container--panelToggle node-graph-panel">
+              <div className="feed-tree__orientation">
+                <Button
+                  type="button"
+                  onClick={() => onExpand("side_panel")}
+                >
+                  Node Panel
+                </Button>
+              </div>
+            </div>
+          )}
           <ForceGraph3D
             ref={fgRef}
             //@ts-ignore
@@ -100,6 +115,18 @@ const FeedGraph = (props: IFeedProps) => {
             }}
             linkWidth={2}
           />
+          {!isBottomPanelExpanded && (
+          <div className="feed-tree__container--panelToggle graph">
+            <div className="feed-tree__orientation">
+              <Button
+                type="button"
+                onClick={() => onExpand("bottom_panel")}
+              >
+                Feed Browser
+              </Button>
+            </div>
+          </div>
+        )}
         </ErrorBoundary>
       ) : (
         <Text>Fetching the Graph....</Text>

--- a/src/components/feed/FeedTree/FeedGraph.tsx
+++ b/src/components/feed/FeedTree/FeedGraph.tsx
@@ -7,9 +7,8 @@ import useResizeObserver from '@react-hook/resize-observer';
 import TreeModel from '../../../api/models/tree.model'
 import {PluginInstance} from '@fnndsc/chrisapi'
 import {ErrorBoundary} from "react-error-boundary";
-import {Text} from '@patternfly/react-core'
+import {Text, Button} from '@patternfly/react-core'
 import './FeedTree.scss';
-import { Button } from "@patternfly/react-core";
 
 
 interface IFeedProps {

--- a/src/components/feed/FeedTree/FeedTree.scss
+++ b/src/components/feed/FeedTree/FeedTree.scss
@@ -56,6 +56,17 @@
 
     &--panelToggle {
       padding-right: 1rem ;
+
+      &.node-graph-panel {
+        position: absolute;
+        right: 0;
+        z-index: 10;
+      }
+
+      &.graph {
+        position: absolute;
+        bottom: 30px;
+      }
     }
   }
 

--- a/src/pages/Feeds/components/FeedView.tsx
+++ b/src/pages/Feeds/components/FeedView.tsx
@@ -154,7 +154,12 @@ export const FeedView: React.FC<FeedViewProps> = ({match: { params: { id } } }: 
             onNodeClick={onNodeClick}
           />
         ) : (
-          <FeedGraph onNodeClick={onNodeClick} />
+          <FeedGraph 
+            onNodeClick={onNodeClick}
+            isSidePanelExpanded={isSidePanelExpanded}
+            isBottomPanelExpanded={isBottomPanelExpanded}
+            onExpand={onClick}
+          />
         )}
       </React.Suspense>
     </GridItem>


### PR DESCRIPTION
Fix for issue #228.

This PR displays the toggle buttons and toggle the panels when the feed graph layout is displayed.

<img width="1910" alt="Screen Shot 2021-04-16 at 02 59 29" src="https://user-images.githubusercontent.com/72573500/114960862-c8084900-9e5f-11eb-943b-ea2dbb143468.png">

<img width="1918" alt="Screen Shot 2021-04-16 at 03 00 03" src="https://user-images.githubusercontent.com/72573500/114960890-d9515580-9e5f-11eb-87eb-b883cfe68fb5.png">

<img width="1920" alt="Screen Shot 2021-04-16 at 03 00 37" src="https://user-images.githubusercontent.com/72573500/114960930-ef5f1600-9e5f-11eb-9709-17d65a061c5b.png">

<img width="1920" alt="Screen Shot 2021-04-16 at 03 01 00" src="https://user-images.githubusercontent.com/72573500/114960945-fb4ad800-9e5f-11eb-9cb2-b70c108ebb44.png">

