### PR TITLE
Add docker-entrypoint.sh for overwriting CUBE url in build/

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,6 @@ COPY --from=builder /app/build /app
 COPY ./docker-entrypoint.sh /docker-entrypoint.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["sirv", "--quiet", "--etag", "--single", "-H", "0.0.0.0", "-p", "3000"]
+ENV HOST=0.0.0.0 PORT=3000
+CMD ["sirv", "--quiet", "--etag", "--single"]
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ This repository contains the reference UI for ChRIS, allowing users to create an
 ![Code Size][code-size]
 
 
+## Quickstart
+
+First, get the [ChRIS backend](https://github.com/FNNDSC/ChRIS_ultron_backEnd)
+running. Assuming the backend is on `http://localhost:8000/api/v1/`:
+
+```shell
+docker run --rm -d --name chris_ui -p 3000:3000 -e REACT_APP_CHRIS_UI_URL=http://localhost:8000/api/v1/ fnndsc/chris_ui:latest
+```
+
 ## Preconditions
 
 ### Install latest Docker. Currently tested platforms:
@@ -17,7 +26,7 @@ This repository contains the reference UI for ChRIS, allowing users to create an
 - Arch Linux
 - macOS 11.X+ (Big Sur)
 
-### Optionally get the backend services up so you can fully test the UI against actual data
+### Get the backend services up so you can fully test the UI against actual data
 
 * Install latest [``Docker Compose``](https://docs.docker.com/compose/)
 * On a Linux machine make sure to add your computer user to the ``docker`` group
@@ -56,10 +65,7 @@ $ sudo rm -r FS
 $ ./unmake.sh
 ```
 
-
-
 </details>
-
 
 
 ## Start UI development server

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,49 @@
+#!/bin/sh -e
+# Motivation: `npm run build` is very slow, the fastest
+#             way to get the UI up is `docker pull ... `
+#             However, the CUBE backend url is hard-coded
+#             to be http://localhost:8000/api/v1/
+# Purpose:    Overwrite the URL of CUBE using a user-specified value.
+#             `sed` is used to patch the `build/` directory.
+#             Next, we downgrade to an underprivileged user
+#             before starting the static web server.
+
+target='http://localhost:8000/api/v1/'
+cube_url="${REACT_APP_CHRIS_UI_URL-nil}"
+
+if [ "$(id -u)" != "0" ]; then
+  if [ "$cube_url" != 'nil' ]; then
+    echo "WARNING: custom value REACT_APP_CHRIS_UI_URL=$cube_url"
+    echo "is set, but container user is not root."
+    echo "This ChRIS_ui will still point to: $target"
+  fi
+  exec "$@"
+fi
+
+# "http://localhost:8000/api/v1/" --> "http:\/\/localhost:8000\/api\/v1\/"
+escape_slash() {
+  echo $1 | sed 's/\//\\\//g'
+}
+
+
+if [ "$cube_url"  != 'nil' ]; then
+  target_pattern=$(escape_slash $target)
+  cube_url_pattern=$(escape_slash $cube_url)
+  for build_file in $(find -type f); do
+    sed -i -e "s/$target_pattern/$cube_url_pattern/g" $build_file
+  done
+fi
+
+# change to a (random) underprivileged user
+
+PUID=${PUID:=$((RANDOM%50000+10000))}
+PGID=${PGID-nil}
+
+if [ "$PGID" = 'nil' ]; then
+  adduser -D -u $PUID chris
+else
+  addgroup -g $PGID chris
+  adduser -D -u $PUID -G chris chris
+fi
+
+exec su chris -c "$(echo $@)"


### PR DESCRIPTION
Please try out [docker.io/fnndsc/chris_ui:1.4.1-rc.1](https://hub.docker.com/layers/fnndsc/chris_ui/1.4.1-rc.1/images/sha256-a224a4dab891695975b6e9f6f8ce96c86709b016978744300ef245a7bcc34859?context=explore)

- `docker-entrypoint.sh` script uses `find ... | sed ...` to overwrite CUBE's URL in `build/` if the environment variable `REACT_APP_CHRIS_UI_URL` is given a value at runtime
- Also the script downgrades to an (either random or given) underprivileged user before starting the web server.
- replace [serve](https://www.npmjs.com/package/serve) with [sirv-cli](https://www.npmjs.com/package/sirv-cli)

Close #231 