### PR TITLE
Eye button fixed in signup page

### DIFF
--- a/src/pages/SignUp/components/SignupForm.tsx
+++ b/src/pages/SignUp/components/SignupForm.tsx
@@ -249,7 +249,7 @@ const SignUpForm: React.FC<SignUpFormProps> = ({
               onClick={() => setShowPassword(!showPassword)}
               aria-label={showPassword? showPasswordAriaLabel : hidePasswordAriaLabel}
             >
-              {showPassword ? <EyeIcon /> : <EyeSlashIcon />}
+              {showPassword ? <EyeSlashIcon /> : <EyeIcon />}
             </Button>
           </InputGroup>
         )}       


### PR DESCRIPTION
@PintoGideon @mairin Fixed the Eye button on the `Signup` page.


![Screenshot from 2021-04-19 19-59-46](https://user-images.githubusercontent.com/64978837/115253420-fd57b400-a149-11eb-998f-3da5bcc40d42.png)
![Screenshot from 2021-04-19 19-59-55](https://user-images.githubusercontent.com/64978837/115253431-0052a480-a14a-11eb-97cb-1701d954cf81.png)

