### PR TITLE
Add error handling to ChRIS file select

### DIFF
--- a/src/components/feed/CreateFeed/createfeed.scss
+++ b/src/components/feed/CreateFeed/createfeed.scss
@@ -80,6 +80,17 @@
   .file-remove {
     cursor: pointer;
   }
+
+  .loading-error-alert {
+    width: 100%;
+    .error-details {
+      padding: 10px;
+      margin: 10px 0px;
+      font-weight: normal;
+      border-left: 1px solid var(--pf-global--danger-color--100);
+    }
+  }
+
 }
 
 /* ChRIS File Select and Local File Upload */


### PR DESCRIPTION
This PR adds error handling to the ChRIS file select page in the Create Feed Wizard, and displays an error message if the ChRIS api returns with a non-200 status (such as an internal server error). Previously, the entire app would crash. 

Fixes: #273 

![image](https://user-images.githubusercontent.com/10372616/124151654-c878af00-da60-11eb-98c1-1357b81f40c5.png)
