### PR TITLE
Fixed the subway stops to show the correct indicators

### DIFF
--- a/src/components/feed/FeedOutputBrowser/FileBrowser.tsx
+++ b/src/components/feed/FeedOutputBrowser/FileBrowser.tsx
@@ -182,7 +182,7 @@ const FileBrowser = (props: FileBrowserProps) => {
       title: (
         <DownloadIcon
           className="download-file-icon"
-          onClick={(e) => handleDownloadClick(e, node)}
+          onClick={(e: any) => handleDownloadClick(e, node)}
         />
       ),
     };

--- a/src/store/resources/reducer.ts
+++ b/src/store/resources/reducer.ts
@@ -25,8 +25,13 @@ const reducer: Reducer<IResourceState> = (state = initialState, action) => {
     }
 
     case ResourceTypes.GET_PLUGIN_INSTANCE_RESOURCE_SUCCESS: {
-      const { id, pluginStatus, pluginLog, pluginDetails } = action.payload;
-      const pluginStatusLabels = getStatusLabels(pluginStatus, pluginDetails);
+      const { id, pluginStatus, pluginLog, pluginDetails, previousStatus } =
+        action.payload;
+      const pluginStatusLabels = getStatusLabels(
+        pluginStatus,
+        pluginDetails,
+        previousStatus
+      );
 
       return {
         ...state,

--- a/src/store/resources/saga.ts
+++ b/src/store/resources/saga.ts
@@ -20,6 +20,7 @@ import {
   getPluginInstanceStatusSuccess,
 } from "./actions";
 import { getPluginFiles } from "../workflows/utils";
+import ChrisAPIClient from "../../api/chrisapiclient";
 
 function* fetchPluginFiles(plugin: PluginInstance) {
   try {
@@ -50,6 +51,17 @@ function* handleGetPluginStatus(instance: PluginInstance) {
       //@ts-ignore
       const pluginStatus = yield pluginDetails.data.summary;
 
+      const previousInstanceId = instance.data.previous_id;
+      let previousStatus = "";
+
+      if (previousInstanceId) {
+        const previousInstance: PluginInstance =
+          yield ChrisAPIClient.getClient().getPluginInstance(
+            previousInstanceId
+          );
+        previousStatus = previousInstance.data.status;
+      }
+
       let parsedStatus: PluginStatusLabels | undefined = undefined;
       if (pluginStatus) {
         parsedStatus = JSON.parse(pluginStatus);
@@ -65,6 +77,7 @@ function* handleGetPluginStatus(instance: PluginInstance) {
         pluginStatus: parsedStatus,
         pluginLog: output,
         pluginDetails: pluginDetails,
+        previousStatus,
       };
       yield put(getPluginInstanceResourceSuccess(payload));
       if (

--- a/src/store/resources/utils.ts
+++ b/src/store/resources/utils.ts
@@ -12,7 +12,8 @@ import {
 
 export function getStatusLabels(
   labels: PluginStatusLabels,
-  pluginDetails: any
+  pluginDetails: any,
+  previousStatus: string
 ) {
   const status = [];
 
@@ -35,11 +36,21 @@ export function getStatusLabels(
       : false;
 
   const currentLabel = statusLabels.indexOf(pluginStatus);
+  let waitingStatus = false;
+
+  if (pluginDetails.data.plugin_type === "fs") {
+    waitingStatus = currentLabel > 0 ? true : false;
+  } else {
+    waitingStatus =
+      currentLabel > 0 && previousStatus === "finishedSuccessfully"
+        ? true
+        : false;
+  }
 
   status[0] = {
     id: 1,
     title: "Waiting",
-    status: currentLabel > 0 ? true : false,
+    status: waitingStatus,
     isCurrentStep: pluginStatus === "waiting" ? true : false,
     error,
     description: "Waiting",
@@ -50,7 +61,7 @@ export function getStatusLabels(
   status[1] = {
     id: 2,
     title: "Scheduling",
-    status: currentLabel > 1 ? true : false,
+    status: currentLabel > 1 && status[0].status === true ? true : false,
     isCurrentStep: pluginStatus === "scheduled" ? true : false,
     error,
     description: "Scheduling",

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -6,6 +6,7 @@ declare module "*.scss";
 
 declare module "@patternfly/react-styles";
 declare module "@patternfly/react-table";
+declare module "@patternfly/react-icons";
 declare module "patternfly-react";
 declare module "d3v4";
 declare module "enzyme-adapter-react-16";
@@ -22,3 +23,4 @@ declare module "react-cornerstone-viewport";
 declare module "react-lazylog";
 declare module "clone";
 declare module "dequal/lite";
+declare module "typesafe-actions";


### PR DESCRIPTION
If the previous instance of a node fails, the status of the node should indicate that it failed at the "Waiting" stage and was "Cancelled" in cube. It does not go through the intermediary steps , which is indicated by a dark color.

![Before_Fix](https://user-images.githubusercontent.com/15992276/124809299-f6ad3180-df2d-11eb-85e0-ab4b37218eb5.png)
![After_Fix](https://user-images.githubusercontent.com/15992276/124809304-f90f8b80-df2d-11eb-88cf-e2afb5dd0c9d.png)
