### PR TITLE
Display error message if node fails

### DIFF
--- a/src/components/feed/NodeDetails/NodeDetails.scss
+++ b/src/components/feed/NodeDetails/NodeDetails.scss
@@ -216,6 +216,14 @@
     }
   }
 
+  .node-details__error-message {
+    font-style: italic;
+  }
+
+  .node-details__error-show-more {
+    color: var(--pf-global--link--Color--light) !important;
+  }
+
   @include media-query(1200px) {
     .pf-l-grid > .pf-m-2-col {
       margin-bottom: 1em;

--- a/src/components/feed/NodeDetails/NodeDetails.tsx
+++ b/src/components/feed/NodeDetails/NodeDetails.tsx
@@ -31,6 +31,7 @@ import PluginTitle from "./PluginTitle";
 import { setFeedLayout } from "../../../store/feed/actions";
 import { useTypedSelector } from "../../../store/hooks";
 import "./NodeDetails.scss";
+import { getErrorCodeMessage } from "./utils";
 
 interface INodeProps {
   expandDrawer: (panel: string) => void;
@@ -61,6 +62,7 @@ const NodeDetails: React.FC<INodeProps> = ({ expandDrawer }) => {
   const [isTerminalVisible, setIsTerminalVisible] = React.useState(false);
   const [isGraphNodeVisible, setIsGraphNodeVisible] = React.useState(false);
   const [isExpanded, setIsExpanded] = React.useState(false);
+  const [isErrorExpanded, setisErrorExpanded] = React.useState(false);
 
   React.useEffect(() => {
     const fetchData = async () => {
@@ -197,7 +199,27 @@ const NodeDetails: React.FC<INodeProps> = ({ expandDrawer }) => {
             {cancelled &&
               renderGridItem(
                 "Error Code",
-                <span>{error_code ? error_code : "None"}</span>
+                <span>
+                  {error_code ?
+                    <span>
+                      {error_code}&nbsp;
+                      {isErrorExpanded &&
+                        <span className="node-details__error-message">
+                          {getErrorCodeMessage(error_code)}&nbsp;
+                        </span>
+                        }
+                        <Button 
+                          variant="link" 
+                          isInline 
+                          className="node-details__error-show-more"
+                          onClick={() => setisErrorExpanded(!isErrorExpanded)}
+                        >
+                          (show {isErrorExpanded ? 'less' : 'more'})
+                        </Button>
+                      </span>
+                      : "None"
+                    }
+                </span>
               )}
           </Grid>
         </ExpandableSection>

--- a/src/components/feed/NodeDetails/utils.ts
+++ b/src/components/feed/NodeDetails/utils.ts
@@ -5,3 +5,27 @@ export function displayDescription(label: any) {
     return label.title;
   } else return "";
 }
+
+// Hard-coded map of error codes to simplified error messages
+export function getErrorCodeMessage(errorCode: string) {
+  const errorCodeMap: Record<string, string> = {
+    CODE01: "Error submitting job to pfcon url",
+    CODE02: "Error getting job status at pfcon",
+    CODE03: "Error fetching zip from pfcon url",
+    CODE04: "Received bad zip file from remote",
+    CODE05: "Couldn't find any plugin instance with correct ID while processing input instances to ts plugin instance",
+    CODE06: "Error while listing swift storage files",
+    CODE07: "Error while uploading file to swift storage",
+    CODE08: "Error while downloading file from swift storage",
+    CODE09: "Error while copying file in swift storage",
+    CODE10: "Got undefined status from remote",
+    CODE11: "Error while listing swift storage files; presumable eventual consistency problem",
+    CODE12: "Error deleting job from pfcon"
+  };
+
+  const errorMessage = errorCodeMap[errorCode];
+  if (errorMessage) {
+    return `ChRIS Internal Error: ${errorMessage}`;
+  }
+  return 'ChRIS Internal Error';
+}


### PR DESCRIPTION
This PR displays an error message if the node fails, next to the error code. Since the frontend does not have access to the same information about the error as the backend, the messages are simplified versions of those logged in the backend:
![image](https://user-images.githubusercontent.com/10372616/124972717-b1096b00-dff8-11eb-90c3-2ca2635a85aa.png)
![image](https://user-images.githubusercontent.com/10372616/124972785-c2527780-dff8-11eb-8257-60010a3c6179.png)
