### PR TITLE
Misc CSS/polish tweaks [WIP]

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-dom": "^16.14.0",
     "react-error-boundary": "^3.1.0",
     "react-force-graph-3d": "^1.18.9",
+    "react-icons": "^4.2.0",
     "react-json-view": "^1.20.2",
     "react-lazylog": "^4.5.3",
     "react-moment": "^0.8.4",

--- a/src/components/feed/FeedDetails/FeedDetails.scss
+++ b/src/components/feed/FeedDetails/FeedDetails.scss
@@ -11,6 +11,7 @@
 .feed-details {
   display: flex;
   margin-top: 10px;
+  margin-bottom: 12px;
 
   &__textarea {
     --pf-c-form-control--BackgroundColor: var(

--- a/src/components/feed/FeedOutputBrowser/FeedOutputBrowser.scss
+++ b/src/components/feed/FeedOutputBrowser/FeedOutputBrowser.scss
@@ -118,6 +118,10 @@
     }
   }
 
+  .header-panel__buttons--togglePanel button span.pf-c-button__icon {
+    margin-right: 0px;
+  }
+
   .header-panel__buttons {
     display: flex;
     justify-content: space-between;
@@ -125,7 +129,7 @@
     margin-right: 0.25em;
 
     button {
-      padding-top: 0;
+      padding: 5px auto;
     }
   }
 

--- a/src/components/feed/FeedTree/FeedTree.tsx
+++ b/src/components/feed/FeedTree/FeedTree.tsx
@@ -9,7 +9,7 @@ import { select, event } from "d3-selection";
 import { v4 as uuidv4 } from "uuid";
 import { zoom as d3Zoom, zoomIdentity } from "d3-zoom";
 import { PluginInstance } from "@fnndsc/chrisapi";
-import { UndoIcon, RedoIcon } from "@patternfly/react-icons";
+import { AiOutlineRotateLeft, AiOutlineRotateRight } from "react-icons/ai";
 import Link from "./Link";
 import NodeWrapper from "./Node";
 import { Datum, TreeNodeDatum, Point } from "./data";
@@ -314,9 +314,9 @@ const FeedTree = (props: AllProps) => {
             className="feed-tree__orientation"
           >
             {orientation === "vertical" ? (
-              <RedoIcon className="feed-tree__orientation--icon" />
+              <AiOutlineRotateLeft className="feed-tree__orientation--icon" />
             ) : (
-              <UndoIcon className="feed-tree__orientation--icon" />
+              <AiOutlineRotateRight className="feed-tree__orientation--icon" />
             )}
           </div>
           <div className="feed-tree__orientation">

--- a/src/components/feed/NodeDetails/NodeDetails.scss
+++ b/src/components/feed/NodeDetails/NodeDetails.scss
@@ -33,7 +33,7 @@
 
   .node-details {
     height: 100%;
-    margin: 0.5em 1em;
+    margin: 0.5em 1em auto;
     &__title {
       display: flex;
       margin: 0.5em 1em;

--- a/src/components/feed/NodeDetails/NodeDetails.scss
+++ b/src/components/feed/NodeDetails/NodeDetails.scss
@@ -35,7 +35,7 @@
     height: 100%;
     &__title {
       display: flex;
-      margin-bottom: 0.5em;
+      margin: 0.5em 1em;
       .pf-c-button {
         --pf-c-button--m-tertiary--BackgroundColor: var(
           --pf-global--palette--white

--- a/src/components/feed/NodeDetails/NodeDetails.scss
+++ b/src/components/feed/NodeDetails/NodeDetails.scss
@@ -36,7 +36,7 @@
     margin: 0.5em 1em auto;
     &__title {
       display: flex;
-      margin: 0.5em 1em;
+      margin: 0.5em auto;
       .pf-c-button {
         --pf-c-button--m-tertiary--BackgroundColor: var(
           --pf-global--palette--white

--- a/src/components/feed/NodeDetails/NodeDetails.scss
+++ b/src/components/feed/NodeDetails/NodeDetails.scss
@@ -2,6 +2,10 @@
 @import "../../../assets/scss/helpers/mixins";
 @import "../../../assets/scss/helpers/pf4-variables";
 
+.pf-c-drawer__panel-main {
+  background-color: rgb(0, 32, 38) !important;
+}
+
 .node-block {
   background: $node-block-background;
   padding-top: 2rem;
@@ -104,7 +108,7 @@
       display: flex;
       justify-content: flex-start;
       gap: 2em;
-      margin-top: 1em;
+      margin: 1em auto;
     }
 
     .pf-c-form-control {

--- a/src/components/feed/NodeDetails/NodeDetails.scss
+++ b/src/components/feed/NodeDetails/NodeDetails.scss
@@ -33,6 +33,7 @@
 
   .node-details {
     height: 100%;
+    margin: 0.5em 1em;
     &__title {
       display: flex;
       margin: 0.5em 1em;

--- a/src/components/feed/NodeDetails/NodeDetails.scss
+++ b/src/components/feed/NodeDetails/NodeDetails.scss
@@ -52,6 +52,10 @@
       &--button {
         // Tells the element to create as much space as possible to it's left
         margin-left: auto;
+        
+       .pf-m-start {
+	  margin-right: 0px;
+	}
       }
 
       &--formInput {


### PR DESCRIPTION
Adjusting spacing so the content on the bottom of the Feed Details title bar isn't so close to the edge and has a little more breathing space.

**Before**

![Screenshot from 2021-07-14 13-16-42](https://user-images.githubusercontent.com/799683/125664823-f772eb54-a674-46fb-a0da-86a73b28a307.png)

**After**
![Screenshot from 2021-07-14 13-17-06](https://user-images.githubusercontent.com/799683/125664877-030f8624-1670-442a-9076-e0fed8eb2ce8.png)
