### PR TITLE
Implemented scale nodes via output size

### DIFF
--- a/src/components/feed/FeedTree/Controls.tsx
+++ b/src/components/feed/FeedTree/Controls.tsx
@@ -40,7 +40,6 @@ export const NodeScaleDropdown = ({ selected, onChange }: NodeScaleDropdownProps
       <SelectOption
         key="size"
         value={labels.get('size')}
-        disabled
       />
     </Select>
   )

--- a/src/components/feed/FeedTree/Node.tsx
+++ b/src/components/feed/FeedTree/Node.tsx
@@ -192,7 +192,10 @@ const NodeWrapper = (props: NodeWrapperProps) => {
       scale = Math.log10(end.getTime() - start.getTime()) / 2
     }
   } else if (overlayScale === 'size') {
-    // props.data.item?.
+    const instanceData = props.data.item?.data;
+    if (instanceData) {
+      scale = parseInt(instanceData?.number_of_workers) *2
+    }
   }
 
   return (


### PR DESCRIPTION
I enabled the output size option in the select component and write overlayScale using number_of_workers assuming it is the size of the node. If I did something wrong, please correct me and I'll fix asap.