### PR TITLE
Lined up quadrants on the feed details screen

### DIFF
--- a/src/pages/Feeds/components/FeedView.tsx
+++ b/src/pages/Feeds/components/FeedView.tsx
@@ -228,7 +228,7 @@ export const FeedView: React.FC<FeedViewProps> = ({
                 <DrawerContent
                   panelContent={
                     <DrawerPanelContent
-                      defaultSize="50%"
+                      defaultSize="49.12%"
                       minSize={"20%"}
                       isResizable
                     >


### PR DESCRIPTION
It will be the best if the bottom panel is also a draggable Drawer, but for now the two top and bottom panels are aligned with changing 50% to 49.12% in top panel size.