### PR TITLE
Make all display card in plugins list page the same height

### DIFF
--- a/src/pages/CatalogPage/CatalogPage.scss
+++ b/src/pages/CatalogPage/CatalogPage.scss
@@ -4,4 +4,5 @@
     font-size: 0.85rem;
     color: var(--pf-global--palette--black-500);
   }
+  height: 100%;
 }


### PR DESCRIPTION
1. Make display card height same by setting child height same as parent. The height of the cards were different(screenshot attached)
![card-height](https://user-images.githubusercontent.com/5582809/139242693-5c383f05-14b1-4b9c-8095-538d268fe957.png)
. 