### PR TITLE
Fixed overflowing text

### DIFF
--- a/src/pages/DataLibrary/components/PACSLookup/QueryResults.tsx
+++ b/src/pages/DataLibrary/components/PACSLookup/QueryResults.tsx
@@ -425,7 +425,7 @@ export const QueryResults: React.FC<QueryResultsProps> = ({
         return (
           <>
             {seriesFiles.length && (
-              <div style={{ marginTop: "-1em" }}>
+              <div style={{ marginTop: "-1em", wordWrap : "break-word"}}>
                 <FileDetailView
                   preview="small"
                   selectedFile={


### PR DESCRIPTION
Text overflowed because of it's lengthy. Setting the wordwrap property to break-word fixes it.
Fixes #390