### PR TITLE
Fixed #408 Required to Re-Authenticate

### DIFF
--- a/src/api/chrisapiclient.ts
+++ b/src/api/chrisapiclient.ts
@@ -21,7 +21,7 @@ class ChrisAPIClient {
 
   static getClient(): Client {
     if (!this.client || !this.isTokenAuthorized) {
-      const token: string = window.sessionStorage.getItem(AUTH_TOKEN_KEY) || '';
+      const token: string = window.localStorage.getItem(AUTH_TOKEN_KEY) || '';
       if (token) {
         this.isTokenAuthorized = true;
       } else {

--- a/src/api/models/base.model.ts
+++ b/src/api/models/base.model.ts
@@ -55,7 +55,7 @@ export interface IActionTypeParam {
 // CHRIS API REQUEST (working)
 export default class ChrisModel {
   static fetchRequest(url: string) {
-    const auth = { token: `${window.sessionStorage.getItem("CHRIS_TOKEN")}` };
+    const auth = { token: `${window.localStorage.getItem("CHRIS_TOKEN")}` };
     const header = {
       "Content-Type": "application/vnd.collection+json",
       Authorization: "Token " + auth.token,

--- a/src/components/detailedView/displays/DicomViewer/index.tsx
+++ b/src/components/detailedView/displays/DicomViewer/index.tsx
@@ -38,7 +38,7 @@ cornerstoneWADOImageLoader.external.dicomParser = dicomParser;
 cornerstoneNIFTIImageLoader.nifti.configure({
   headers: {
     "Content-Type": "application/vnd.collection+json",
-    Authorization: "Token " + window.sessionStorage.getItem("CHRIS_TOKEN"),
+    Authorization: "Token " + window.localStorage.getItem("CHRIS_TOKEN"),
   },
   method: "get",
   responseType: "arrayBuffer",

--- a/src/components/feed/Preview/displays/NiftiDisplay.tsx
+++ b/src/components/feed/Preview/displays/NiftiDisplay.tsx
@@ -17,7 +17,7 @@ cornerstoneNIFTIImageLoader.external.cornerstone = cornerstone;
 cornerstoneNIFTIImageLoader.nifti.configure({
   headers: {
     "Content-Type": "application/vnd.collection+json",
-    Authorization: "Token " + window.sessionStorage.getItem("CHRIS_TOKEN"),
+    Authorization: "Token " + window.localStorage.getItem("CHRIS_TOKEN"),
   },
   method: "get",
   responseType: "arrayBuffer",

--- a/src/pages/VisualizationPage/index.tsx
+++ b/src/pages/VisualizationPage/index.tsx
@@ -43,7 +43,7 @@ import "./index.scss";
 cornerstoneNIFTIImageLoader.nifti.configure({
   headers: {
     "Content-Type": "application/vnd.collection+json",
-    Authorization: "Token " + window.sessionStorage.getItem("CHRIS_TOKEN"),
+    Authorization: "Token " + window.localStorage.getItem("CHRIS_TOKEN"),
   },
   method: "get",
   responseType: "arrayBuffer",

--- a/src/store/user/reducer.ts
+++ b/src/store/user/reducer.ts
@@ -4,10 +4,10 @@ import { IUserState, UserActionTypes } from "./types";
 
 // Type-safe initialState
 const initialState: IUserState = {
-  username: window.sessionStorage.getItem("USERNAME"),
-  token: window.sessionStorage.getItem("CHRIS_TOKEN"),
+  username: window.localStorage.getItem("USERNAME"),
+  token: window.localStorage.getItem("CHRIS_TOKEN"),
   isRememberMe: false,
-  isLoggedIn: !!window.sessionStorage.getItem("CHRIS_TOKEN"),
+  isLoggedIn: !!window.localStorage.getItem("CHRIS_TOKEN"),
 };
 
 // ***** NOTE: Working *****

--- a/src/store/user/saga.ts
+++ b/src/store/user/saga.ts
@@ -16,8 +16,8 @@ function* handleResponse(action: any) {
         username: action.payload.username,
       })
     );
-    window.sessionStorage.setItem("CHRIS_TOKEN", action.payload.token);
-    window.sessionStorage.setItem("USERNAME", action.payload.username);
+    window.localStorage.setItem("CHRIS_TOKEN", action.payload.token);
+    window.localStorage.setItem("USERNAME", action.payload.username);
   } catch (error) {
     setAuthError();
   }
@@ -32,8 +32,8 @@ function* watchLoginRequest() {
 // ----------------------------------------------------------------
 
 function handleLogout() {
-  window.sessionStorage.removeItem("CHRIS_TOKEN");
-  window.sessionStorage.removeItem("USERNAME");
+  window.localStorage.removeItem("CHRIS_TOKEN");
+  window.localStorage.removeItem("USERNAME");
 }
 function* watchLogoutRequest() {
   yield takeEvery(UserActionTypes.LOGOUT_USER, handleLogout);


### PR DESCRIPTION
fixes #408 
we were using session storage to store username and Chris_token , session storage doesnot persists data across tabs and once the tab is closed it gets deleted , hence we were required to re-authenticate while opening links in new tab , using local storage instead of session storage , solves this..

**GIF:**


![ezgif com-gif-maker](https://user-images.githubusercontent.com/90280586/165702771-7084a4c3-3807-477c-836e-bb7eb72dfe7d.gif)

