### PR TITLE
Fix node version to 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN npm install
 RUN npm run build 
 
 
-FROM node:16-alpine
+FROM node:18-alpine
 
 RUN yarn global add sirv-cli
 

--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -25,7 +25,7 @@
 
 
 
-FROM node:16 as builder
+FROM node:18 as builder
 MAINTAINER fnndsc "dev@babymri.org"
 
 # Pass a UID on build command line (see above) to set internal UID


### PR DESCRIPTION
@Sandip117 I noticed you updated the node version a week ago here:

https://github.com/FNNDSC/ChRIS_ui/commit/f618b46fc5603eb931c2f83e87e8b7480ee674a2#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R32

Please avoid staging unrelated changes to your git commits.

Anyways, there are actually several places where the node version is hard-coded, we should change them all at once.