### PR TITLE
Self-updating build version string

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,12 +1,3 @@
-.dockerignore
-Dockerfile*
-.gitignore
-.travis.yml
-.git
-LICENSE
-README.md
-
-
 # dev container stuff that might end up here bc of the dev environment
 node_modules
 .config/
@@ -16,3 +7,4 @@ node_modules
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,34 +16,11 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Get info
-        id: determine
-        shell: python
+        id: info
         run: |
-          # Create a list of tags for the container image, including
-          # :latest, the date in YYYYMMDD, the git tag (optional), and the git short sha,
-          # for the registries docker.io and ghcr.io
-
-          import os
-          import datetime
-          import itertools
-          import subprocess as sp
-
-          git_refs = []
-          if os.getenv('GITHUB_REF', '').startswith('refs/tags/'):
-              git_refs.append(os.getenv('GITHUB_REF')[10:])
-
-          registries = ['docker.io', 'ghcr.io']
-          repo = os.environ['GITHUB_REPOSITORY'].lower()
-          short_sha = sp.check_output(['git', 'rev-parse', '--short', 'HEAD'], text=True).strip()
-          today = datetime.date.today().strftime(r'%Y%m%d')
-          tags = ['latest', short_sha, today] + git_refs
-
-          names = ','.join(''.join(c) for c in itertools.product(
-              (r + '/' for r in registries),
-              [repo],
-              (':' + t for t in tags)
-          ))
-          print(f'::set-output name=tags::{names}')
+          version="$(npm run -s print-version | tr '+' '-')"
+          echo "Version: $version"
+          echo "::set-output name=version_string::$version"
 
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
@@ -63,7 +40,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -72,13 +49,15 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
-          tags: ${{ steps.determine.outputs.tags }}
+          tags: |
+            docker.io/fnndsc/chris_ui:latest
+            docker.io/fnndsc/chris_ui:${{ steps.info.outputs.version_string }}
+            ghcr.io/fnndsc/chris_ui:latest
+            ghcr.io/fnndsc/chris_ui:${{ steps.info.outputs.version_string }}
           platforms: linux/amd64,linux/arm64
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-          build-args: |
-            REACT_APP_CHRIS_UI_BUILD_COMMIT=${{ github.sha }}
 
       - name: Update DockerHub description
         uses: peter-evans/dockerhub-description@v2

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "lint": "eslint '*/**/*.{js,ts,tsx}' --quiet --fix"
+    "lint": "eslint '*/**/*.{js,ts,tsx}' --quiet --fix",
+    "print-version": "./print_version.sh"
   },
   "resolutions": {
     "react-scripts/postcss-preset-env/postcss-custom-properties": "^10.0.0"

--- a/print_version.sh
+++ b/print_version.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# purpose: print out a version string: YYYYMMDD.X+commit(-dirty?)
+#          YYYYMMDD = current date
+#                 X = number of merge commits since the tag version-0
+#            commit = HEAD commit short sha
+#            -drity = suffix indicating there are uncommitted changes
+
+printf "%s.%s+%s%s" \
+  "$(date '+%Y%m%d')" \
+  "$(git rev-list --use-bitmap-index --count --merges version-0..HEAD)" \
+  "$(git rev-parse --short HEAD)" \
+  "$(git diff --quiet src/ || echo '-dirty')"

--- a/src/pages/Dashboard/Dashboard.scss
+++ b/src/pages/Dashboard/Dashboard.scss
@@ -1,6 +1,6 @@
 @import "../../assets/scss/helpers/pf4-variables";
 
-.commit-name {
+.build-version {
   color: #5c5c5c;
 }
 

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -56,10 +56,10 @@ const DashboardPage = (props: DashboardProps) => {
   const outlineSearch = <MdOutlineImageSearch style={style} />
   const magicWand = <FaMagic style={style} />
 
-  const buildDate = preval`module.exports = new Date()`
-  const buildInfo = process.env.REACT_APP_CHRIS_UI_BUILD_COMMIT ?
-    <span>Git commit: <code className="commit-name">{process.env.REACT_APP_CHRIS_UI_BUILD_COMMIT}</code></span> :
-    <span></span>
+  const buildVersion = preval`
+    const { execSync } = require('child_process')
+    module.exports = execSync('npm run -s print-version', {encoding: 'utf-8'})
+  `
 
   return (
     <Wrapper>
@@ -71,14 +71,7 @@ const DashboardPage = (props: DashboardProps) => {
           <b> Let&apos;s get started.</b>
         </p>
         <p>
-          <span>
-            Built on:{" "}
-            <b>
-              <Moment format="DD MMM YYYY @ HH:mm">{buildDate}</Moment>
-            </b>
-          </span>
-          <br />
-          {buildInfo}
+          Build: <code className="build-version">{buildVersion}</code>
         </p>
         {children}
       </PageSection>


### PR DESCRIPTION
"Built on" timestamp replaced by a **self-updating** "build version" string. Its format is as follows:

```
YYYYMMDD.X+commit(-dirty?)

#          YYYYMMDD = current date
#                 X = number of merge commits since the tag version-0
#            commit = HEAD commit short sha
#            -drity = suffix indicating there are uncommitted changes
```

![image](https://user-images.githubusercontent.com/20404439/176497332-f1b0021d-1dcd-4cf2-9a41-cf582d81dcba.png)

The same string (but with illegal characters replaced) is used to tag docker images.

In this proof-of-concept the "build version string" is very verbose. It's ok to merge as-is. Alternatively, we can discuss how we want to change it. It's verbose to show off what's possible. Changes can be made to `print_version.sh`.

In a follow-up PR we can discuss and implement different styles to be applied to the version string (for example, maybe the commit SHA should be dimmer, or the version number in bold?).