### PR TITLE
Improved 'Share a Feed'  UX Experience

### DIFF
--- a/src/components/feed/ShareFeed/InputUser.tsx
+++ b/src/components/feed/ShareFeed/InputUser.tsx
@@ -1,48 +1,60 @@
-import React, { useState } from "react";
+import React, { useState } from 'react'
 import {
   TextInput,
   Form,
   Label,
   Button,
-  ActionGroup
-} from "@patternfly/react-core";
+  ActionGroup,
+  Alert,
+} from '@patternfly/react-core'
 
 interface InputUserProps {
-  handleModalClose: () => void;
-  handleCreate: (username: string) => void;
+  handleModalClose: () => void
+  handleCreate: (username: string) => void
+  error: string
+  cleanError: () => void
+  loading: boolean
 }
 
 const InputUser: React.FC<InputUserProps> = ({
   handleCreate,
-  handleModalClose
+  handleModalClose,
+  error,
+  cleanError,
+  loading,
 }) => {
-  const [value, setValue] = useState("");
+  const [value, setValue] = useState('')
 
-  const handleChange = (value: string) => setValue(value);
+  const handleChange = (value: string) => {
+    setValue(value)
+    cleanError()
+  }
   const handleSubmit = (
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
   ) => {
-    event.preventDefault();
-    handleCreate(value);
-  };
+    event.preventDefault()
+    handleCreate(value)
+  }
 
   return (
     <div>
       <Form>
-        <Label className="share-feed-label">People</Label>
+        <Label className="share-feed-label">Enter an username</Label>
         <TextInput
           value={value}
           type="text"
           onChange={handleChange}
           aria-label="text input example"
         />
+        {error && <Alert variant="danger" title={error} />}
+        {loading && <span>Sharing Feed...</span>}
         <ActionGroup>
           <Button onClick={handleSubmit}>Save</Button>
           <Button onClick={() => handleModalClose()}>Cancel</Button>
         </ActionGroup>
       </Form>
     </div>
-  );
-};
+  )
+}
 
-export default InputUser;
+export default InputUser

--- a/src/components/feed/ShareFeed/ShareFeed.tsx
+++ b/src/components/feed/ShareFeed/ShareFeed.tsx
@@ -1,32 +1,46 @@
-import React, { useState } from "react";
-import { Feed } from "@fnndsc/chrisapi";
-import { Button } from "@patternfly/react-core";
-import { FaCodeBranch } from "react-icons/fa";
-import InputUser from "./InputUser";
-import ShareModal from "./ShareModal";
-import "./sharefeed.scss";
+import React, { useState } from 'react'
+import { Feed } from '@fnndsc/chrisapi'
+import { Button } from '@patternfly/react-core'
+import { FaCodeBranch } from 'react-icons/fa'
+import InputUser from './InputUser'
+import ShareModal from './ShareModal'
+import './sharefeed.scss'
 
 interface ShareFeedProps {
-  feed?: Feed;
+  feed?: Feed
 }
 
 const ShareFeed: React.FC<ShareFeedProps> = ({ feed }) => {
-  const [showOverlay, setShowOverlay] = useState(false);
+  const [showOverlay, setShowOverlay] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
 
-  const handleAddClick = () => setShowOverlay((prev) => !prev);
+  const handleAddClick = () => setShowOverlay((prev) => !prev)
   const handleCreate = async (username: string) => {
     if (!feed) {
-      return;
+      return
     }
-    await feed.put({
-      owner: username,
-    });
-
-    handleModalClose();
-  };
+    try {
+      setLoading(true)
+      await feed.put({
+        owner: username,
+      })
+      setLoading(false)
+      handleModalClose()
+    } catch (error) {
+      //@ts-ignore
+      setError(error.response.data.owner[0])
+      setLoading(false)
+    }
+  }
   const handleModalClose = () => {
-    setShowOverlay((prevState) => !prevState);
-  };
+    setShowOverlay((prevState) => !prevState)
+    cleanError()
+  }
+
+  const cleanError = () => {
+    setError('')
+  }
 
   return (
     <>
@@ -43,10 +57,13 @@ const ShareFeed: React.FC<ShareFeedProps> = ({ feed }) => {
         <InputUser
           handleModalClose={handleModalClose}
           handleCreate={handleCreate}
+          error={error}
+          cleanError={cleanError}
+          loading={loading}
         />
       </ShareModal>
     </>
-  );
-};
+  )
+}
 
-export default ShareFeed;
+export default ShareFeed

--- a/src/components/feed/ShareFeed/ShareModal.tsx
+++ b/src/components/feed/ShareFeed/ShareModal.tsx
@@ -1,16 +1,16 @@
-import React from "react";
-import { Modal, ModalVariant } from "@patternfly/react-core";
+import React from 'react'
+import { Modal, ModalVariant } from '@patternfly/react-core'
 
 interface ShareModalProps {
-  handleModalClose: () => void;
-  showOverlay: boolean;
-  children?: any;
+  handleModalClose: () => void
+  showOverlay: boolean
+  children?: any
 }
 
 const ShareModal: React.FC<ShareModalProps> = ({
   showOverlay,
   handleModalClose,
-  children
+  children,
 }) => {
   return (
     <Modal
@@ -22,7 +22,7 @@ const ShareModal: React.FC<ShareModalProps> = ({
     >
       {children}
     </Modal>
-  );
-};
+  )
+}
 
-export default ShareModal;
+export default ShareModal


### PR DESCRIPTION
- Added error handling for unregistered users.

![Screenshot from 2022-08-03 11-09-08](https://user-images.githubusercontent.com/15992276/182643291-b0c049f5-d1fd-41fe-9388-703fcfaea99b.png)

- Added a 'Sharing a feed message' as the put request to modify the feed resource is being made to cube.
