### PR TITLE
fix hint content overflowing the screen in pac lookup mobile screen

### DIFF
--- a/src/assets/scss/base/_typography.scss
+++ b/src/assets/scss/base/_typography.scss
@@ -20,7 +20,14 @@ h3 {
   margin-top: 0.25em;
   margin-bottom: 0.25em;
 }
-
+h1.ant-typography {
+  @media (max-width: 560px) {
+    font-size: 2em;
+  }
+  @media (max-width: 420px) {
+    font-size: 1.5em;
+  }
+}
 h1 + h2 {
   margin-top: 0;
   margin-bottom: 0.5em;

--- a/src/components/common/info/InfoIcon.tsx
+++ b/src/components/common/info/InfoIcon.tsx
@@ -31,7 +31,7 @@ const InfoIcon = ({
     <div>
       <Title>
         {title}
-        <Popover placement="bottomRight" trigger="hover" content={content}>
+        <Popover placement="bottomLeft" trigger="hover" content={content}>
           <FcInfo
             style={{
               height: '1em',

--- a/src/components/feed/NodeDetails/NodeDetails.scss
+++ b/src/components/feed/NodeDetails/NodeDetails.scss
@@ -252,10 +252,17 @@
 Steps Design Icon
 
 ******/
-
-.ant-popover-inner-content {
-  width: 45rem !important;
-  padding: 0 !important;
+.ant-popover {
+  width: 100%!important;
+  top: 15;
+  
+  .pf-c-hint__actions {
+    margin: 0;
+  }
+  
+  @media (min-width: 760px) {
+    width: 70%!important;
+  }
 }
 
 .ReactVirtualized__Grid__innerScrollContainer {


### PR DESCRIPTION
### What this PR does.

- fixes #649 
**Before**
1. Mobile screen
<img width="374" alt="image" src="https://user-images.githubusercontent.com/47438585/195209195-f108a0b1-3e3b-4dd8-8e81-f2fc8fb43794.png">

2. Nedium screen 
<img width="406" alt="image" src="https://user-images.githubusercontent.com/47438585/195209415-7b28a23f-9949-481e-aed8-ce259ed2baf6.png">

3. Large Screen
<img width="803" alt="image" src="https://user-images.githubusercontent.com/47438585/195209526-88effc8a-8f86-4212-bf88-5f6cf130e1ea.png">


**After**
1. Mobile screen
<img width="206" alt="image" src="https://user-images.githubusercontent.com/47438585/195209746-40910162-e576-47fc-be36-083897ec2990.png">

2. Medium screen
<img width="407" alt="image" src="https://user-images.githubusercontent.com/47438585/195209857-bbd655b0-dd01-4309-9ec1-ddbe09d61b62.png">

3. Large screen
<img width="806" alt="image" src="https://user-images.githubusercontent.com/47438585/195210035-aae7c664-02b1-4139-b89e-ffcbcdbfa472.png">
