### PR TITLE
fix drawer covering search box and button

### DIFF
--- a/src/components/catalog/DisplayPage.tsx
+++ b/src/components/catalog/DisplayPage.tsx
@@ -226,7 +226,7 @@ const DisplayPage = ({
             resources.length > 0 &&
             resources.map((resource) => {
               return (
-                <Col key={resource.data ? resource.data.id : ""} span={8}>
+                <Col key={resource.data ? resource.data.id : ""} span={8} lg={8} sm={12} xs={24}>
                   <Card
                     hoverable
                     style={{
@@ -281,7 +281,7 @@ const DisplayPage = ({
   };
 
   const panelContent = (
-    <DrawerPanelContent defaultSize="30%" minSize="10%" isResizable>
+    <DrawerPanelContent defaultSize="25%" className="panelcontent">
       <DrawerHead>
         <DrawerActions>
           <DrawerCloseButton
@@ -358,7 +358,7 @@ const DisplayPage = ({
           </>
         )}
       </DrawerHead>
-      <DrawerContentBody>
+      <DrawerContentBody >
         {selectedResource && showPipelineButton && (
           <Tree pipelineName={selectedResource.data.name} />
         )}
@@ -376,7 +376,7 @@ const DisplayPage = ({
         onPerPageSelect={onPerPageSelect}
       />
       <div>
-        <Drawer isExpanded={isExpanded}>
+        <Drawer isExpanded={isExpanded} isInline>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>
           </DrawerContent>

--- a/src/pages/CatalogPage/CatalogPage.scss
+++ b/src/pages/CatalogPage/CatalogPage.scss
@@ -20,4 +20,10 @@
   }
 }
 
+.panelcontent {
+  @media (max-width: 767px) {
+    margin-top: 5rem;
+    border-top: 1px solid rgba(199, 198, 198, 0.381);
+  }
+}
 


### PR DESCRIPTION
### What this PR does.
- Fix the search box and button not showing when the drawer opens (the drawer was initially overlaying)
- Fix cards squeezing up on smaller screens (the cards were three columns on all screen sizes, this PR makes it responsive)


#### IMAGES

**Before**
1. **Mobile Screen**
- Without drawer
<img width="207" alt="Screenshot 2022-10-12 at 13 41 13" src="https://user-images.githubusercontent.com/47438585/195325533-18318e80-89cd-4d10-8042-23e7cedb8401.png">

- With drawer
<img width="207" alt="Screenshot 2022-10-12 at 13 41 27" src="https://user-images.githubusercontent.com/47438585/195325713-5ac2a75d-6b5b-4ce4-9f1d-3813f873fed6.png">



2. **Medium Screen**
- Without drawer
<img width="404" alt="Screenshot 2022-10-12 at 13 41 53" src="https://user-images.githubusercontent.com/47438585/195325795-842fd20e-3bb1-45f5-aa43-0516e44c156e.png">

- With drawer
<img width="406" alt="Screenshot 2022-10-12 at 13 42 08" src="https://user-images.githubusercontent.com/47438585/195325866-c6718fb4-eff9-4edb-a429-c714a4c12800.png">



3. **Large Screen**
- Without drawer
<img width="556" alt="Screenshot 2022-10-12 at 13 42 40" src="https://user-images.githubusercontent.com/47438585/195325951-afdcca05-ec8f-4870-8234-6debbeaca590.png">

- With drawer
<img width="550" alt="Screenshot 2022-10-12 at 13 42 54" src="https://user-images.githubusercontent.com/47438585/195326052-6d1bbd2c-3afe-47fb-9993-2345fcd5062c.png">


**After**

1. **Mobile Screen**
- Without drawer
<img width="202" alt="Screenshot 2022-10-12 at 13 43 55" src="https://user-images.githubusercontent.com/47438585/195326207-0f0524e2-3889-421a-956b-eed0026a6f93.png">

- With drawer
<img width="206" alt="Screenshot 2022-10-12 at 13 44 06" src="https://user-images.githubusercontent.com/47438585/195326252-c8927b91-68c6-4134-83b8-03f943858540.png">

2**. Medium Screen**
- Without drawer
<img width="408" alt="Screenshot 2022-10-12 at 13 44 24" src="https://user-images.githubusercontent.com/47438585/195326292-347eb1bf-1cbd-4518-8910-34333b9be0d3.png">

- With drawer
<img width="404" alt="Screenshot 2022-10-12 at 13 44 37" src="https://user-images.githubusercontent.com/47438585/195326351-f56b7b12-7c26-409e-808c-332999d4b2f2.png">

3. **Large Screen**
- Without drawer
<img width="553" alt="Screenshot 2022-10-12 at 13 45 28" src="https://user-images.githubusercontent.com/47438585/195326404-622220e5-d959-45b2-917f-2f72942acf14.png">

- With drawer
<img width="558" alt="Screenshot 2022-10-12 at 13 45 46" src="https://user-images.githubusercontent.com/47438585/195326490-9dfc8f08-1b71-4ccf-a947-7fbef39aef73.png">
