### PR TITLE
Copy-Pastable Chrs download command

### DIFF
--- a/src/components/feed/CreateFeed/createfeed.scss
+++ b/src/components/feed/CreateFeed/createfeed.scss
@@ -229,7 +229,7 @@ Styles for pipelines
 **/
 
 .pf-c-popover {
-  height: 700px;
+  height: fit-content;
   padding: 0;
 }
 

--- a/src/components/feed/NodeDetails/NodeDetails.tsx
+++ b/src/components/feed/NodeDetails/NodeDetails.tsx
@@ -1,4 +1,5 @@
 import React, { Fragment, useState } from "react";
+
 import Moment from "react-moment";
 // Added Tooltip
 import {
@@ -68,7 +69,7 @@ const NodeDetails: React.FC<INodeProps> = ({ expandDrawer }) => {
   
   // Method 2.
   const { id } = useParams();
-  const baseUrl = window.location.origin;
+  const baseUrl = process.env.CHRIS_UI_URL;
   const copyText = "Copy To Clipboard";
   const doneCopyText = "Copied!"
   const [isCopied, SetIsCopied] = React.useState(false);
@@ -113,7 +114,7 @@ const NodeDetails: React.FC<INodeProps> = ({ expandDrawer }) => {
 
   // Method 2
   const copyPathToClipboard = () => {
-    const path = `${baseUrl}/api/v1/plugins/instances/${id}/files/`
+    const path = `${baseUrl}/plugins/instances/${id}/files/`
     const command = `chrs download ${path}`
     navigator.clipboard.writeText(command);
     SetIsCopied(true);

--- a/src/components/feed/NodeDetails/NodeDetails.tsx
+++ b/src/components/feed/NodeDetails/NodeDetails.tsx
@@ -69,7 +69,7 @@ const NodeDetails: React.FC<INodeProps> = ({ expandDrawer }) => {
   
   // Method 2.
   const { id } = useParams();
-  const baseUrl = process.env.CHRIS_UI_URL;
+  const baseUrl = process.env.REACT_APP_CHRIS_UI_URL;
   const copyText = "Copy To Clipboard";
   const doneCopyText = "Copied!"
   const [isCopied, SetIsCopied] = React.useState(false);

--- a/src/components/feed/NodeDetails/NodeDetails.tsx
+++ b/src/components/feed/NodeDetails/NodeDetails.tsx
@@ -244,10 +244,7 @@ const NodeDetails: React.FC<INodeProps> = ({ expandDrawer }) => {
             </Button>
 
             {/* Editing button */}
-            
-            {/* <div style={{ margin: '100px' }}> */}
-            {/* const PopoverBasic: React.FunctionComponent = () => ( */}
-              <div style={{ margin: '50px' }}>
+              <div>
                 <Popover_patternfly
                   aria-label="Basic popover"
                   headerContent={<div>Popover header</div>}
@@ -268,9 +265,6 @@ const NodeDetails: React.FC<INodeProps> = ({ expandDrawer }) => {
                   </Button>
                 </Popover_patternfly>
               </div>
-            {/* ); */}
-            {/* </div> */}
-
             {/* End Editing button */}
           </div>
 

--- a/src/components/feed/NodeDetails/NodeDetails.tsx
+++ b/src/components/feed/NodeDetails/NodeDetails.tsx
@@ -8,6 +8,7 @@ import {
   GridItem,
   ExpandableSection,
   Tooltip,
+  Popover as Popover_patternfly,
 } from "@patternfly/react-core";
 
 import { Popover, Progress } from "antd";
@@ -107,10 +108,11 @@ const NodeDetails: React.FC<INodeProps> = ({ expandDrawer }) => {
     pluginParameters,
   ]);
 
-    const copyPathToClipboard = () => {
-    const path = `${baseUrl}plugins/instances/${id}/files/`
-    const command = `chrs download ${path}`
-    navigator.clipboard.writeText(command);
+  const path = `${baseUrl}plugins/instances/${id}/files/`
+  const chrsCommandPath = `chrs download ${path}`;
+
+  const copyPathToClipboard = () => {
+    navigator.clipboard.writeText(chrsCommandPath);
     SetIsCopied(!isCopied);
   }
 
@@ -241,11 +243,35 @@ const NodeDetails: React.FC<INodeProps> = ({ expandDrawer }) => {
               Download Files
             </Button>
 
-            <Tooltip aria="none" aria-live="polite" content={isCopied ? doneCopyText : copyText}>
-              <Button onClick={copyPathToClipboard} icon={<FaCopy />}>
-                Copy Download Command
-              </Button>
-            </Tooltip>
+            {/* Editing button */}
+            
+            {/* <div style={{ margin: '100px' }}> */}
+            {/* const PopoverBasic: React.FunctionComponent = () => ( */}
+              <div style={{ margin: '50px' }}>
+                <Popover_patternfly
+                  aria-label="Basic popover"
+                  headerContent={<div>Popover header</div>}
+                  bodyContent={
+                    <div>
+                      <input className="pf-c-form-control" readOnly type="text" value={chrsCommandPath} aria-label="Readonly input example" />
+                      <Tooltip aria="none" aria-live="polite" content={isCopied ? doneCopyText : copyText}>
+                        <Button aria-label="Clipboard" variant="plain" onClick={copyPathToClipboard} >
+                          <FaCopy />
+                        </Button>
+                      </Tooltip>
+                    </div>
+                  }
+                  footerContent="Popover footer"
+                >
+                  <Button icon={<FaCopy />}>
+                    Copy Download Command
+                  </Button>
+                </Popover_patternfly>
+              </div>
+            {/* ); */}
+            {/* </div> */}
+
+            {/* End Editing button */}
           </div>
 
           <div className="node-details__actions_second">

--- a/src/components/feed/NodeDetails/NodeDetails.tsx
+++ b/src/components/feed/NodeDetails/NodeDetails.tsx
@@ -100,9 +100,7 @@ const NodeDetails: React.FC<INodeProps> = ({ expandDrawer }) => {
     pluginParameters,
   ]);
   
-  const path = selectedPlugin?.collection.items[0].links.find((obj:any) => {
-    return obj.rel === "files"
-  }).href
+  const path = selectedPlugin?.collection.items[0].links.find((obj:any) => (obj.rel === "files")).href
   const chrsCommandPath = `chrs download ${path}`;
 
   const copyPathToClipboard = () => {

--- a/src/components/feed/NodeDetails/NodeDetails.tsx
+++ b/src/components/feed/NodeDetails/NodeDetails.tsx
@@ -117,7 +117,7 @@ const NodeDetails: React.FC<INodeProps> = ({ expandDrawer }) => {
     const path = `${baseUrl}/plugins/instances/${id}/files/`
     const command = `chrs download ${path}`
     navigator.clipboard.writeText(command);
-    SetIsCopied(true);
+    SetIsCopied(!isCopied);
   }
   // End Method 2
 

--- a/src/components/feed/NodeDetails/NodeDetails.tsx
+++ b/src/components/feed/NodeDetails/NodeDetails.tsx
@@ -37,6 +37,7 @@ import { getErrorCodeMessage } from "./utils";
 import AddPipeline from "../AddPipeline/AddPipeline";
 import { SpinContainer } from "../../common/loading/LoadingContent";
 import { useFeedBrowser } from "../FeedOutputBrowser/useFeedBrowser";
+import { ClipboardCopy } from '@patternfly/react-core';
 interface INodeProps {
   expandDrawer: (panel: string) => void;
 }
@@ -61,9 +62,6 @@ const NodeDetails: React.FC<INodeProps> = ({ expandDrawer }) => {
     (state) => state.instance.selectedPlugin
   );
   const { download, downloadAllClick } = useFeedBrowser();
-  const copyText = "Copy To Clipboard";
-  const doneCopyText = "Successfully Copied to Clipboard!"
-  const [isCopied, SetIsCopied] = React.useState(false);
   const { plugin, instanceParameters, pluginParameters } = nodeState;
   const [isTerminalVisible, setIsTerminalVisible] = React.useState(false);
   const [isExpanded, setIsExpanded] = React.useState(false);
@@ -100,13 +98,8 @@ const NodeDetails: React.FC<INodeProps> = ({ expandDrawer }) => {
     pluginParameters,
   ]);
   
-  const path = selectedPlugin?.collection.items[0].links.find((obj:any) => (obj.rel === "files")).href
-  const chrsCommandPath = `chrs download ${path}`;
-
-  const copyPathToClipboard = () => {
-    navigator.clipboard.writeText(chrsCommandPath);
-    SetIsCopied(!isCopied);
-  }
+  const APIURL = selectedPlugin?.collection.items[0].links.find((obj:any) => (obj.rel === "files")).href
+  const chrsCommand = `chrs download ${APIURL}`;
 
   const text =
     plugin && instanceParameters && pluginParameters
@@ -242,8 +235,8 @@ const NodeDetails: React.FC<INodeProps> = ({ expandDrawer }) => {
                   hasAutoWidth
                   bodyContent={
                     <div>
-                      <p>Copy and Paste the URL below into your chrs cli to download the files</p>
-                      <div className="pf-c-clipboard-copy">
+                      <p>Run the command below in a terminal to download the files</p>
+                      {/* <div className="pf-c-clipboard-copy">
                       <div className="pf-c-clipboard-copy__group">
                       <input className="pf-c-form-control" readOnly type="text" value={chrsCommandPath} aria-label="Readonly input example" />
                       <Tooltip aria="none" aria-live="polite" content={isCopied? copyText: doneCopyText}>
@@ -261,7 +254,10 @@ const NodeDetails: React.FC<INodeProps> = ({ expandDrawer }) => {
                        </button>
                        </Tooltip>
                       </div>
-                      </div>
+                      </div> */}
+                       <ClipboardCopy isReadOnly hoverTip="Copy To Clipboard" clickTip="Successfully Copied to Clipboard!">
+                        {chrsCommand}
+                       </ClipboardCopy>
                     </div>
                   }
                 >

--- a/src/components/feed/NodeDetails/NodeDetails.tsx
+++ b/src/components/feed/NodeDetails/NodeDetails.tsx
@@ -6,7 +6,6 @@ import {
   Grid,
   GridItem,
   ExpandableSection,
-  Tooltip,
   Popover as Popover_patternfly,
 } from "@patternfly/react-core";
 
@@ -38,6 +37,7 @@ import AddPipeline from "../AddPipeline/AddPipeline";
 import { SpinContainer } from "../../common/loading/LoadingContent";
 import { useFeedBrowser } from "../FeedOutputBrowser/useFeedBrowser";
 import { ClipboardCopy } from '@patternfly/react-core';
+import { getFilesHref } from './helper';
 interface INodeProps {
   expandDrawer: (panel: string) => void;
 }
@@ -98,7 +98,7 @@ const NodeDetails: React.FC<INodeProps> = ({ expandDrawer }) => {
     pluginParameters,
   ]);
   
-  const APIURL = selectedPlugin?.collection.items[0].links.find((obj:any) => (obj.rel === "files")).href
+  const APIURL = getFilesHref(selectedPlugin);
   const chrsCommand = `chrs download ${APIURL}`;
 
   const text =

--- a/src/components/feed/NodeDetails/NodeDetails.tsx
+++ b/src/components/feed/NodeDetails/NodeDetails.tsx
@@ -1,7 +1,6 @@
-import React, { Fragment, useState } from "react";
+import React, { Fragment } from "react";
 
 import Moment from "react-moment";
-// Added Tooltip
 import {
   Button,
   Grid,
@@ -18,7 +17,6 @@ import {
   PluginInstanceDescendantList,
   PluginParameterList,
 } from "@fnndsc/chrisapi";
-// Added FaCopy
 import {
   FaDownload,
   FaTerminal,
@@ -39,9 +37,6 @@ import { getErrorCodeMessage } from "./utils";
 import AddPipeline from "../AddPipeline/AddPipeline";
 import { SpinContainer } from "../../common/loading/LoadingContent";
 import { useFeedBrowser } from "../FeedOutputBrowser/useFeedBrowser";
-// useParams
-import { useParams } from "react-router";
-
 interface INodeProps {
   expandDrawer: (panel: string) => void;
 }
@@ -65,12 +60,9 @@ const NodeDetails: React.FC<INodeProps> = ({ expandDrawer }) => {
   const selectedPlugin = useTypedSelector(
     (state) => state.instance.selectedPlugin
   );
-
   const { download, downloadAllClick } = useFeedBrowser();
-  const { id } = useParams();
-  const baseUrl = process.env.REACT_APP_CHRIS_UI_URL;
   const copyText = "Copy To Clipboard";
-  const doneCopyText = "Copied!"
+  const doneCopyText = "Successfully Copied to Clipboard!"
   const [isCopied, SetIsCopied] = React.useState(false);
   const { plugin, instanceParameters, pluginParameters } = nodeState;
   const [isTerminalVisible, setIsTerminalVisible] = React.useState(false);
@@ -107,8 +99,10 @@ const NodeDetails: React.FC<INodeProps> = ({ expandDrawer }) => {
     instanceParameters,
     pluginParameters,
   ]);
-
-  const path = `${baseUrl}plugins/instances/${id}/files/`
+  
+  const path = selectedPlugin?.collection.items[0].links.find((obj:any) => {
+    return obj.rel === "files"
+  }).href
   const chrsCommandPath = `chrs download ${path}`;
 
   const copyPathToClipboard = () => {
@@ -242,32 +236,42 @@ const NodeDetails: React.FC<INodeProps> = ({ expandDrawer }) => {
             <Button onClick={downloadAllClick} icon={<FaDownload />}>
               Download Files
             </Button>
-
-            {/* Editing button */}
-              <div>
-                <Popover_patternfly
-                  aria-label="Basic popover"
-                  headerContent={<div>Popover header</div>}
+            <Popover_patternfly
+                  id="node-details-popover"
+                  aria-label="Download command popover"
+                  position="bottom"
+                  headerContent={<div>chrs Download Files</div>}
+                  hasAutoWidth
                   bodyContent={
                     <div>
+                      <p>Copy and Paste the URL below into your chrs cli to download the files</p>
+                      <div className="pf-c-clipboard-copy">
+                      <div className="pf-c-clipboard-copy__group">
                       <input className="pf-c-form-control" readOnly type="text" value={chrsCommandPath} aria-label="Readonly input example" />
-                      <Tooltip aria="none" aria-live="polite" content={isCopied ? doneCopyText : copyText}>
-                        <Button aria-label="Clipboard" variant="plain" onClick={copyPathToClipboard} >
-                          <FaCopy />
-                        </Button>
-                      </Tooltip>
+                      <Tooltip aria="none" aria-live="polite" content={isCopied? copyText: doneCopyText}>
+                      <button 
+                       id="copy-button-1" 
+                       aria-labelledby="copy-button-1 text-input-1" 
+                       aria-disabled="false" aria-label="Copy to clipboard" 
+                       className="pf-c-button pf-m-control" 
+                       type="button" 
+                       onClick={copyPathToClipboard}
+                       data-ouia-safe="true" 
+                       style={{height: "fit-content"}}
+                       data-ouia-component-id="OUIA-Generated-Button-control-2">
+                        <FaCopy />
+                       </button>
+                       </Tooltip>
+                      </div>
+                      </div>
                     </div>
                   }
-                  footerContent="Popover footer"
                 >
                   <Button icon={<FaCopy />}>
                     Copy Download Command
                   </Button>
-                </Popover_patternfly>
-              </div>
-            {/* End Editing button */}
+            </Popover_patternfly>
           </div>
-
           <div className="node-details__actions_second">
             <Popover
               className="node-details__popover"

--- a/src/components/feed/NodeDetails/NodeDetails.tsx
+++ b/src/components/feed/NodeDetails/NodeDetails.tsx
@@ -1,10 +1,12 @@
-import React, { Fragment } from "react";
+import React, { Fragment, useState } from "react";
 import Moment from "react-moment";
+// Added Tooltip
 import {
   Button,
   Grid,
   GridItem,
   ExpandableSection,
+  Tooltip,
 } from "@patternfly/react-core";
 
 import { Popover, Progress } from "antd";
@@ -14,11 +16,13 @@ import {
   PluginInstanceDescendantList,
   PluginParameterList,
 } from "@fnndsc/chrisapi";
+// Added FaCopy
 import {
   FaDownload,
   FaTerminal,
   FaCalendarAlt,
   FaWindowClose,
+  FaCopy,
 } from "react-icons/fa";
 import AddNode from "../AddNode/AddNode";
 import DeleteNode from "../DeleteNode";
@@ -33,6 +37,8 @@ import { getErrorCodeMessage } from "./utils";
 import AddPipeline from "../AddPipeline/AddPipeline";
 import { SpinContainer } from "../../common/loading/LoadingContent";
 import { useFeedBrowser } from "../FeedOutputBrowser/useFeedBrowser";
+// useParams
+import { useParams } from "react-router";
 
 interface INodeProps {
   expandDrawer: (panel: string) => void;
@@ -57,7 +63,17 @@ const NodeDetails: React.FC<INodeProps> = ({ expandDrawer }) => {
   const selectedPlugin = useTypedSelector(
     (state) => state.instance.selectedPlugin
   );
+
   const { download, downloadAllClick } = useFeedBrowser();
+  
+  // Method 2.
+  const { id } = useParams();
+  const baseUrl = window.location.origin;
+  const copyText = "Copy To Clipboard";
+  const doneCopyText = "Copied!"
+  const [isCopied, SetIsCopied] = React.useState(false);
+  // End Method 2.
+
 
   const { plugin, instanceParameters, pluginParameters } = nodeState;
   const [isTerminalVisible, setIsTerminalVisible] = React.useState(false);
@@ -94,6 +110,15 @@ const NodeDetails: React.FC<INodeProps> = ({ expandDrawer }) => {
     instanceParameters,
     pluginParameters,
   ]);
+
+  // Method 2
+  const copyPathToClipboard = () => {
+    const path = `${baseUrl}/api/v1/plugins/instances/${id}/files/`
+    const command = `chrs download ${path}`
+    navigator.clipboard.writeText(command);
+    SetIsCopied(true);
+  }
+  // End Method 2
 
   const text =
     plugin && instanceParameters && pluginParameters
@@ -221,6 +246,14 @@ const NodeDetails: React.FC<INodeProps> = ({ expandDrawer }) => {
             <Button onClick={downloadAllClick} icon={<FaDownload />}>
               Download Files
             </Button>
+
+            {/* Method 2 */}
+            <Tooltip aria="none" aria-live="polite" content={isCopied ? doneCopyText : copyText}>
+              <Button onClick={copyPathToClipboard} icon={<FaCopy />}>
+                Copy chrs Download Command
+              </Button>
+            </Tooltip>
+            {/* End Method 2 */}
           </div>
 
           <div className="node-details__actions_second">

--- a/src/components/feed/NodeDetails/NodeDetails.tsx
+++ b/src/components/feed/NodeDetails/NodeDetails.tsx
@@ -66,16 +66,11 @@ const NodeDetails: React.FC<INodeProps> = ({ expandDrawer }) => {
   );
 
   const { download, downloadAllClick } = useFeedBrowser();
-  
-  // Method 2.
   const { id } = useParams();
   const baseUrl = process.env.REACT_APP_CHRIS_UI_URL;
   const copyText = "Copy To Clipboard";
   const doneCopyText = "Copied!"
   const [isCopied, SetIsCopied] = React.useState(false);
-  // End Method 2.
-
-
   const { plugin, instanceParameters, pluginParameters } = nodeState;
   const [isTerminalVisible, setIsTerminalVisible] = React.useState(false);
   const [isExpanded, setIsExpanded] = React.useState(false);
@@ -112,14 +107,12 @@ const NodeDetails: React.FC<INodeProps> = ({ expandDrawer }) => {
     pluginParameters,
   ]);
 
-  // Method 2
-  const copyPathToClipboard = () => {
-    const path = `${baseUrl}/plugins/instances/${id}/files/`
+    const copyPathToClipboard = () => {
+    const path = `${baseUrl}plugins/instances/${id}/files/`
     const command = `chrs download ${path}`
     navigator.clipboard.writeText(command);
     SetIsCopied(!isCopied);
   }
-  // End Method 2
 
   const text =
     plugin && instanceParameters && pluginParameters
@@ -248,13 +241,11 @@ const NodeDetails: React.FC<INodeProps> = ({ expandDrawer }) => {
               Download Files
             </Button>
 
-            {/* Method 2 */}
             <Tooltip aria="none" aria-live="polite" content={isCopied ? doneCopyText : copyText}>
               <Button onClick={copyPathToClipboard} icon={<FaCopy />}>
-                Copy chrs Download Command
+                Copy Download Command
               </Button>
             </Tooltip>
-            {/* End Method 2 */}
           </div>
 
           <div className="node-details__actions_second">

--- a/src/components/feed/NodeDetails/helper.tsx
+++ b/src/components/feed/NodeDetails/helper.tsx
@@ -1,0 +1,10 @@
+/**
+ * Extract the required API URI of the selected feed.
+ * 
+ * @param plugin the selected plugin
+ * @returns the API URI of the selected feed as a string.
+ */
+
+export function getFilesHref(plugin: any) {
+    return plugin?.collection.items[0].links.find((obj:any) => (obj.rel === "files")).href
+}


### PR DESCRIPTION
**Description:** 
We added a function to allow users to copy the chrs download command based #404 issue. The command `chrs download`  is an efficient way to download a large number of files from ChRIS. 


<img width="539" alt="Screen Shot 2022-10-26 at 15 39 55" src="https://user-images.githubusercontent.com/37863089/198041394-e394aa5e-fef0-4b1f-bb06-bf937e1b1677.png">

**How to test the feature**
Prerequisite: Download the [chrs](https://github.com/FNNDSC/chrs) cli. 
1. click the copy command button as seen in the above image
2. paste the command in the chrs cli to download the files of that specific feed

**Result** 

<img width="1107" alt="Screen Shot 2022-10-15 at 20 35 35" src="https://user-images.githubusercontent.com/37863089/196002769-644afef1-acbe-448f-ab1d-0cf666aa80b1.png">

fixes #404
