### PR TITLE
fixed text-overflowing-out-of-their-card-subcategories-of-main-categori…

### DIFF
--- a/src/pages/DataLibrary/components/UserLibrary/Browser.tsx
+++ b/src/pages/DataLibrary/components/UserLibrary/Browser.tsx
@@ -259,7 +259,7 @@ function FileCard({ file, browserType }: { file: any; browserType: string }) {
         isSelectableRaised
       >
         <CardHeader>
-          <CardTitle>
+          <CardTitle style={{overflow: 'hidden'}}>
             <Button icon={<FaFile />} variant="link" style={{ padding: "0" }}>
               <b>
                 {columnLayout === "single" ? fileName : elipses(fileName, 40)}


### PR DESCRIPTION
What does this PR do ?

Fixes #675 

fixed the text Overflowing out of their Card in Sub Categories of Main Categories - Library Page 

![Overflowing out of their Card in Sub Categories of Main Categories - Library Page](https://user-images.githubusercontent.com/29509047/195717439-41f3c56a-d390-4180-8711-b5fb59609d98.png)
