### PR TITLE
Fix create account button functionality

### DIFF
--- a/src/pages/LogIn/Login.tsx
+++ b/src/pages/LogIn/Login.tsx
@@ -8,7 +8,7 @@ import {
   HelperText,
   HelperTextItem,
 } from "@patternfly/react-core";
-import { FaInfo } from "react-icons/fa";
+import { BsInfoCircleFill } from "react-icons/bs";
 import ChRIS_Logo from "../../assets/images/chris-logo.png";
 import ChRIS_Logo_inline from "../../assets/images/chris-logo-inline.png";
 import LoginFormComponent from "./components/LoginForm";
@@ -48,7 +48,7 @@ const LogInPage: React.FC = () => {
         Forgot username or password?
       </LoginMainFooterBandItem>
       <HelperText>
-        <HelperTextItem icon={<FaInfo />}>
+        <HelperTextItem icon={<BsInfoCircleFill />}>
           <i>Please Contact a ChRIS admin for a new password</i>
         </HelperTextItem>
       </HelperText>

--- a/src/pages/LogIn/components/LoginForm.tsx
+++ b/src/pages/LogIn/components/LoginForm.tsx
@@ -6,8 +6,8 @@ import { useNavigate } from "react-router-dom";
 import { useLocation } from "react-router";
 import { LoginForm } from "@patternfly/react-core";
 import ChrisApiClient from "@fnndsc/chrisapi";
-import { AiFillExclamationCircle } from "react-icons/ai";
 import { useCookies } from "react-cookie";
+import { HelperText, HelperTextItem } from "@patternfly/react-core";
 
 interface IPropsFromDispatch {
   setAuthToken: typeof setAuthToken;
@@ -55,7 +55,7 @@ const LoginFormComponent: React.FC<AllProps> = ({ setAuthToken }: AllProps) => {
           (() =>
             //@ts-ignore
             error.response
-              ? "Invalid Credentials"
+              ? "Invalid credentials"
               : "There was a problem connecting to the server!")()
         );
         setShowHelperText(true);
@@ -98,10 +98,12 @@ const LoginFormComponent: React.FC<AllProps> = ({ setAuthToken }: AllProps) => {
   let helperText;
   if (showHelperText) {
     helperText = (
-      <>
-        <AiFillExclamationCircle />
-        <span> {errorMessage}</span>
-      </>
+        <HelperText>
+          <HelperTextItem variant="error" hasIcon>
+            {errorMessage}
+          </HelperTextItem>
+        </HelperText>
+       
     );
   }
 

--- a/src/pages/SignUp/components/SignupForm.tsx
+++ b/src/pages/SignUp/components/SignupForm.tsx
@@ -204,7 +204,7 @@ const SignUpForm: React.FC<SignUpFormProps> = ({
         <FormAlert>
           <Alert
             variant="danger"
-            title={"There Has Been A problem connecting to the server"}
+            title={"There Has been a problem connecting to the server"}
             aria-live="polite"
             isInline
           />
@@ -289,7 +289,13 @@ const SignUpForm: React.FC<SignUpFormProps> = ({
       </FormGroup>
 
       <ActionGroup>
-        <Button variant="primary" type="submit">
+        <Button
+          variant="primary"
+          type="submit"
+          isDisabled={
+            !emailState.email && !passwordState.password && !emailState.email
+          }
+        >
           {loading ? "Loading...." : "Create Account"}
         </Button>
         <Button variant="secondary">


### PR DESCRIPTION
The create account button is disabled when the required fields are empty. The disabled attribute can be set to keep a user from clicking on the button until some other condition has been met (email and password field).

Before:
<img width="1653" alt="Screenshot 2022-10-14 at 13 28 33" src="https://user-images.githubusercontent.com/63148200/195848263-27f71388-30f2-422b-a89c-df0cd43670f6.png">
After:
<img width="1679" alt="Screenshot 2022-10-14 at 13 31 56" src="https://user-images.githubusercontent.com/63148200/195848506-d232b79f-e25e-421e-bd7f-e480c14fd200.png">
