### PR TITLE
Added  "not found" for search filter of plugins/pipelines/compute

### DIFF
--- a/src/components/catalog/DisplayPage.tsx
+++ b/src/components/catalog/DisplayPage.tsx
@@ -14,6 +14,8 @@ import {
   Button,
   Alert,
   TextInput,
+
+  
 } from "@patternfly/react-core";
 import { Card, Col, Row } from "antd";
 import ReactJSON from "react-json-view";
@@ -24,6 +26,7 @@ import Tree from "./Tree";
 import { PipelineList } from "@fnndsc/chrisapi";
 import ChrisAPIClient from "../../api/chrisapiclient";
 import { generatePipelineWithData } from "../feed/CreateFeed/utils/pipelines";
+import { EmptyStateTable } from "../common/emptyTable";
 
 interface PageState {
   perPage: number;
@@ -222,9 +225,9 @@ const DisplayPage = ({
       )}
       <div className="site-card-wrapper">
         <Row gutter={16}>
-          {resources &&
-            resources.length > 0 &&
-            resources.map((resource) => {
+          {(resources &&
+            resources.length > 0 )?
+            (resources.map((resource) => {
               return (
                 <Col key={resource.data ? resource.data.id : ""} span={8} lg={8} sm={12} xs={24}>
                   <Card
@@ -270,8 +273,22 @@ const DisplayPage = ({
                   </Card>
                 </Col>
               );
-            })}
-        </Row>
+              })):(
+                
+                <Col offset={8}>
+                  <EmptyStateTable
+                  cells={[]}
+                  rows={[]}
+                  caption=""
+                  title="No results found"
+                  description=""
+                  />
+              </Col>
+  
+              )
+              }
+            </Row>
+        
       </div>
     </Grid>
   );


### PR DESCRIPTION
#668

Added "not found" for non-existing search inputs of plugins, pipelines and compute
@PintoGideon  @mairin @jennydaman Could you please review this
Before:

![image](https://user-images.githubusercontent.com/88175932/195994257-4f052284-eeb3-4425-9afa-f9f634b73025.png)


After:

![image](https://user-images.githubusercontent.com/88175932/195994277-06646a40-06f5-44e1-823b-5bbbe25b2219.png)
