### PR TITLE
Fix: Mobile screen responsiveness on Library page

### DIFF
--- a/src/pages/DataLibrary/components/UserLibrary/index.tsx
+++ b/src/pages/DataLibrary/components/UserLibrary/index.tsx
@@ -535,7 +535,7 @@ const DataLibrary = () => {
       </div>
       <Tabs
         style={{
-          width: '50%',
+          width: '100%',
         }}
         activeKey={activeTabKey}
         onSelect={handleTabClick}


### PR DESCRIPTION
This PR adds basic responsive support for the `library` page of ChRIS UI. The purpose is to create content that adjusts smoothly to various screen sizes.
Before: 
<img width="426" alt="Screenshot 2022-10-19 at 17 19 39" src="https://user-images.githubusercontent.com/63148200/196749282-75916f08-f345-49c7-9ed0-85685c076e7e.png">
After:
<img width="429" alt="Screenshot 2022-10-19 at 17 20 01" src="https://user-images.githubusercontent.com/63148200/196749359-46952517-eadd-4c04-b31b-d789051eeaee.png">