### PR TITLE
Fix: Mobile responsiveness  on create analysis screen

### DIFF
--- a/src/components/feed/AddNode/helperComponents/ReviewGrid.tsx
+++ b/src/components/feed/AddNode/helperComponents/ReviewGrid.tsx
@@ -17,34 +17,32 @@ export const PluginDetails: React.FC<PluginDetailsProps> = ({
   const pluginName = `${title ? title : `${name} v.${version}`}`
   return (
     <>
-      <GridItem span={2}>
+      <GridItem sm={4} md={2}>
         <span className="review__title">Selected Plugin:</span>
       </GridItem>
-      <GridItem span={10}>
-        <span className="review__value">
-          {pluginName}
-        </span>
+      <GridItem sm={8} md={10}>
+        <span className="review__value">{pluginName || "N/A"}</span>
       </GridItem>
-      <GridItem span={2}>
+      <GridItem sm={4} md={2}>
         <span className="review__title">Type of Plugin:</span>
       </GridItem>
-      <GridItem span={10}>
+      <GridItem sm={8} md={10}>
         <span className="review__value">
           {selectedPlugin && selectedPlugin.data.type.toUpperCase()}
         </span>
       </GridItem>
-      <GridItem span={2}>
+      <GridItem sm={4} md={2}>
         <span className="review__title">Plugin Configuration:</span>
       </GridItem>
-      <GridItem span={10}>
-        <span className="required-text">{generatedCommand}</span>
+      <GridItem sm={8} md={10}>
+        <span className="required-text">{generatedCommand || "N/A"}</span>
       </GridItem>
-      <GridItem span={2}>
+      <GridItem sm={4} md={2}>
         <span className="review__title">Compute Enviroment:</span>
       </GridItem>
-      <GridItem span={10}>
-        <span className="review__value">{computeEnvironment}</span>
+      <GridItem sm={8} md={10}>
+        <span className="review__value">{computeEnvironment || "N/A"}</span>
       </GridItem>
     </>
-  )
+  );
 }

--- a/src/components/feed/CreateFeed/Review.tsx
+++ b/src/components/feed/CreateFeed/Review.tsx
@@ -6,17 +6,11 @@ import "./createfeed.scss";
 import { PluginDetails } from "../AddNode/helperComponents/ReviewGrid";
 import { ChrisFileDetails, LocalFileDetails } from "./helperComponents";
 
-
 const Review: React.FunctionComponent = () => {
   const { state } = useContext(CreateFeedContext);
 
-  const {
-    feedName,
-    feedDescription,
-    tags,
-    chrisFiles,
-    localFiles
-  } = state.data;
+  const { feedName, feedDescription, tags, chrisFiles, localFiles } =
+    state.data;
   const {
     dropdownInput,
     requiredInput,
@@ -78,28 +72,28 @@ const Review: React.FunctionComponent = () => {
       <br />
       <br />
       <Grid hasGutter={true}>
-        <GridItem span={2}>
+        <GridItem sm={4} md={2}>
           <span className="review__title">Feed Name</span>
         </GridItem>
-        <GridItem span={10}>
+        <GridItem sm={8} md={10}>
           <span className="review__value">{feedName}</span>
         </GridItem>
-        <GridItem span={2}>
+        <GridItem sm={4} md={2}>
           <span className="review__title">Feed Description</span>
         </GridItem>
-        <GridItem span={10}>
-          <span className="review__value">{feedDescription}</span>
+        <GridItem sm={8} md={10}>
+          <span className="review__value">{feedDescription || "N/A"}</span>
         </GridItem>
-        <GridItem span={2}>
+        <GridItem sm={4} md={2}>
           <span className="review__title">Tags</span>
         </GridItem>
-        <GridItem span={10}>
-          <span className="review__value">{tagList}</span>
+        <GridItem sm={8} md={10}>
+          <span className="review__value">{tagList || "N/A"}</span>
         </GridItem>
-        <GridItem span={2}>
+        <GridItem sm={4} md={2}>
           <span className="review__title">Selected Pipeline</span>
         </GridItem>
-        <GridItem span={10}>
+        <GridItem sm={8} md={10}>
           <span className="review__value">
             {pipelineName ? pipelineName : "None Selected"}
           </span>


### PR DESCRIPTION
The goal of this responsive design is to make the `create analysis`  page responsive so that it detects a user screen size and changes the layout accordingly.

Before:
<img width="342" alt="Screenshot 2022-10-19 at 17 03 59" src="https://user-images.githubusercontent.com/63148200/196762516-991169f7-3102-4578-995a-f2d6e278a915.png">
After:
<img width="438" alt="Screenshot 2022-10-19 at 18 24 10" src="https://user-images.githubusercontent.com/63148200/196762579-3730983d-4333-47b6-96ca-de50036468da.png">
