### PR TITLE
making plugin selcetable without deselecting the previous selected one when creating new analysis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27416,6 +27416,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
       "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+      "deprecated": "Use your platform's native performance.now() and performance.timeOrigin.",
       "dependencies": {
         "browser-process-hrtime": "^1.0.0"
       }

--- a/src/components/catalog/ComputeCatalog.tsx
+++ b/src/components/catalog/ComputeCatalog.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import ChrisAPIClient from "../../api/chrisapiclient";
 import DisplayPage from "./DisplayPage";
+import { Title, EmptyState, EmptyStateIcon, Spinner } from '@patternfly/react-core';
 
 const ComputeCatalog = () => {
   const [computeResources, setComputeResources] = React.useState<any[]>();
@@ -13,7 +14,7 @@ const ComputeCatalog = () => {
 
   const { page, perPage, search } = pageState;
   const [selectedCompute, setSelectedCompute] = React.useState<any>();
-
+  const [loading, setLoading] = React.useState(false)
   const onSetPage = (_event: any, page: number) => {
     setPageState({
       ...pageState,
@@ -39,6 +40,7 @@ const ComputeCatalog = () => {
       page: number,
       search: string
     ) {
+      setLoading(true)
       const offset = perPage * (page - 1);
       const client = ChrisAPIClient.getClient();
       const params = {
@@ -57,6 +59,7 @@ const ComputeCatalog = () => {
           };
         });
       }
+      setLoading(false)
     }
 
     fetchPipelines(perPage, page, search);
@@ -68,6 +71,21 @@ const ComputeCatalog = () => {
       search,
     });
   };
+
+
+  if (loading) {
+    return <>
+      <EmptyState>
+        <EmptyStateIcon variant="container" component={Spinner} />
+        <Title headingLevel='h4'>
+          Pipelines loading...please wait
+        </Title>
+      </EmptyState>
+    </>
+  }
+
+
+  
   return (
     <>
       <DisplayPage

--- a/src/components/catalog/PipelineCatalog.tsx
+++ b/src/components/catalog/PipelineCatalog.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect } from 'react'
 import ChrisAPIClient from '../../api/chrisapiclient'
 import DisplayPage from './DisplayPage'
+import { Title, EmptyState, EmptyStateIcon, Spinner } from '@patternfly/react-core';
+
 
 const PipelineCatalog = () => {
   const [pipelines, setPipelines] = React.useState<any[]>()
@@ -15,6 +17,7 @@ const PipelineCatalog = () => {
 
   const { page, perPage, search } = pageState
   const [selectedPipeline, setSelectedPipeline] = React.useState<any>()
+  const [loading, setLoading] = React.useState(false)
 
   const onSetPage = (_event: any, page: number) => {
     setPageState({
@@ -41,6 +44,8 @@ const PipelineCatalog = () => {
       page: number,
       search: string,
     ) {
+      setLoading(true)
+
       const offset = perPage * (page - 1)
       const client = ChrisAPIClient.getClient()
       const params = {
@@ -67,6 +72,8 @@ const PipelineCatalog = () => {
           }
         })
       }
+      setLoading(false)
+
     }
 
     fetchPipelines(perPage, page, search)
@@ -82,6 +89,19 @@ const PipelineCatalog = () => {
       ...pageState,
       search,
     })
+  }
+
+
+
+  if (loading) {
+    return <>
+      <EmptyState>
+        <EmptyStateIcon variant="container" component={Spinner} />
+        <Title headingLevel='h4'>
+          Pipelines loading...please wait
+        </Title>
+      </EmptyState>
+    </>
   }
   return (
     <>

--- a/src/components/catalog/PluginCatalog.tsx
+++ b/src/components/catalog/PluginCatalog.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import ChrisAPIClient from "../../api/chrisapiclient";
 import DisplayPage from "./DisplayPage";
+import { Title, EmptyState, EmptyStateIcon, Spinner } from '@patternfly/react-core';
 
 const PluginCatalog = () => {
   const [plugins, setPlugins] = React.useState<any[]>();
@@ -13,6 +14,7 @@ const PluginCatalog = () => {
 
   const { page, perPage, search } = pageState;
   const [selectedPlugin, setSelectedPlugin] = React.useState<any>();
+  const [loading, setLoading] = React.useState(false)
 
   const onSetPage = (_event: any, page: number) => {
     setPageState({
@@ -35,6 +37,7 @@ const PluginCatalog = () => {
   };
   useEffect(() => {
     async function fetchPlugins(perPage: number, page: number, search: string) {
+      setLoading(true)
       const offset = perPage * (page - 1);
       const client = ChrisAPIClient.getClient();
       const params = {
@@ -53,6 +56,8 @@ const PluginCatalog = () => {
           };
         });
       }
+      setLoading(false)
+
     }
 
     fetchPlugins(perPage, page, search);
@@ -64,6 +69,17 @@ const PluginCatalog = () => {
       search,
     });
   };
+
+  if (loading) {
+    return <>
+      <EmptyState>
+        <EmptyStateIcon variant="container" component={Spinner} />
+        <Title headingLevel='h4'>
+          Pipelines loading...please wait
+        </Title>
+      </EmptyState>
+    </>
+  }
 
   return (
     <>

--- a/src/components/feed/CreateFeed/DataPacks.tsx
+++ b/src/components/feed/CreateFeed/DataPacks.tsx
@@ -147,11 +147,7 @@ const DataPacks: React.FC<DataPacksReduxProp> = (props: DataPacksReduxProp) => {
                     })
                   }}
                   checked={selectedPlugin?.data.id === plugin.data.id}
-                  isDisabled={
-                    selectedPlugin && selectedPlugin.data.id !== plugin.data.id
-                      ? true
-                      : false
-                  }
+                  
                 />
                 <DataListItemCells
                   dataListCells={[


### PR DESCRIPTION
  ![Screenshot (105)](https://user-images.githubusercontent.com/67365597/197208293-c059874f-74bb-4cab-8801-f5cce192e1e3.png)

fixes #689 Prior to  this, when creating a new analysis, when a plugin is selected, you can't select another one until you deselect the selected one. the image below shows no plugin(select option) is disalbed for selection

@jennydaman 
