### PR TITLE
Enable scale nodes by output size

### DIFF
--- a/src/components/feed/FeedTree/Controls.tsx
+++ b/src/components/feed/FeedTree/Controls.tsx
@@ -11,7 +11,6 @@ interface NodeScaleDropdownProps {
 export const NodeScaleDropdown = ({ selected, onChange }: NodeScaleDropdownProps) => {
   const [open, setOpen] = useState(false);
 
-  // TODO: enable output size
   const labels: Map<FeedTreeScaleType, string> = new Map([
     ['time', 'Compute Time'],
     ['size', 'Output Size']
@@ -36,7 +35,7 @@ export const NodeScaleDropdown = ({ selected, onChange }: NodeScaleDropdownProps
       selections={labels.get(selected)}
     >
       <SelectOption key="time" value={labels.get("time")} />
-      <SelectOption key="size" value={labels.get("size")} disabled />
+      <SelectOption key="size" value={labels.get("size")}  />
     </Select>
   );
 }


### PR DESCRIPTION
![chrisoutputsize](https://user-images.githubusercontent.com/93627129/199854602-044a61e3-1ddc-4383-982f-12c5eee27f2b.png)

I've implemented and enabled the output size option.  The scale is based on the size of the output directory of each plugin.  The 
file list is fetched when the component mounts and a reduce function is run, generating the total size of the directory.  In the screenshot you can see the result of a file conversion, a reduction in the directory size by half.
