### PR TITLE
added responsiveness of the feed view list and node details steps

### DIFF
--- a/src/components/common/dataTableToolbar/dataTableToolbar.scss
+++ b/src/components/common/dataTableToolbar/dataTableToolbar.scss
@@ -7,14 +7,9 @@
 
  // Data table search bar
 .datatable-toolbar{
-    margin: 0 0 1rem;
-    max-width: 500px;
+    margin: 0 0.5rem 0.2rem 0;
    .pf-c-input-group .toolbar-label, input{
         font-size: 0.875rem;
         font-weight: 500;
-    }
-    .pf-c-input-group .toolbar-label{
-        padding: 0 2rem;
-        
     }
 }

--- a/src/components/feed/NodeDetails/NodeDetails.scss
+++ b/src/components/feed/NodeDetails/NodeDetails.scss
@@ -7,10 +7,7 @@
 }
 
 @media screen and (min-width: 768px) {
-  .pf-c-drawer
-    > .pf-c-drawer__main
-    > .pf-c-drawer__panel.pf-m-resizable
-    > .pf-c-drawer__panel-main {
+  .pf-c-drawer > .pf-c-drawer__main > .pf-c-drawer__panel.pf-m-resizable > .pf-c-drawer__panel-main {
     flex-shrink: 0;
   }
 }
@@ -55,16 +52,10 @@
       display: flex;
       margin: 0.5em auto;
       .pf-c-button {
-        --pf-c-button--m-tertiary--BackgroundColor: var(
-          --pf-global--palette--white
-        ) !important;
-        -pf-c-button--m-tertiary--hover--backgroundcolor: var(
-          --pf-global--palette--black-300
-        ) !important;
+        --pf-c-button--m-tertiary--BackgroundColor: var(--pf-global--palette--white) !important;
+        -pf-c-button--m-tertiary--hover--backgroundcolor: var(--pf-global--palette--black-300) !important;
 
-        --pf-c-button--m-tertiary--focus--BackgroundColor: var(
-          --pf-global--palette--black-300
-        ) !important;
+        --pf-c-button--m-tertiary--focus--BackgroundColor: var(--pf-global--palette--black-300) !important;
       }
       &--button {
         // Tells the element to create as much space as possible to it's left
@@ -141,32 +132,6 @@
       margin-top: 1rem;
     }
 
-    &__status-descriptions {
-      .ant-steps-item {
-        overflow: visible !important;
-      }
-
-      .ant-steps-item-icon {
-        display: none;
-      }
-
-      .ant-steps-item-description {
-        color: #b8bbbe !important;
-        max-width: 60px !important;
-        margin-top: 0.5em;
-        font-size: 12px;
-      }
-
-      .ant-steps-horizontal:not(.ant-steps-label-vertical)
-        .ant-steps-item-tail {
-        display: none !important;
-      }
-
-      .ant-steps-item-title::after {
-        display: none;
-      }
-    }
-
     &__status {
       .ant-steps-item-icon {
         width: 28px !important;
@@ -174,25 +139,47 @@
         font-size: 12px !important;
         border-radius: 30px !important;
         line-height: 20px !important;
-        margin: 0 2px 0 2px !important;
         cursor: pointer;
+        margin: 0 0 0 2px;
         padding-top: 3px;
         padding-right: 0.25px;
+      }
+
+      .ant-steps-horizontal:not(.ant-steps-label-vertical) .ant-steps-item-tail {
+        display: none !important;
+      }
+
+      .ant-steps-item-title::after {
+        display: none;
+      }
+
+       @media(min-width:1024px){
+        .ant-steps-item-tail{
+          margin-left: 15px !important;
+        }
+      }
+     
+      .ant-steps-item {
+        overflow: visible !important;
+      }
+
+      .ant-steps-item-description {
+        color: #b8bbbe !important;
+        margin-top: 0.5em;
+        font-size: 12px;
+        text-align: left;
       }
 
       .ant-steps-horizontal:not(.ant-steps-label-vertical) .ant-steps-item {
         padding-left: 0;
       }
 
-      .ant-steps-horizontal:not(.ant-steps-label-vertical)
-        .ant-steps-item-tail {
+      .ant-steps-horizontal:not(.ant-steps-label-vertical) .ant-steps-item-tail {
         display: outline !important;
       }
 
       .ant-steps-item-finish,
-      > .ant-steps-item-container
-        > .ant-steps-item-content
-        > .ant-steps-item-description {
+      > .ant-steps-item-container > .ant-steps-item-content > .ant-steps-item-description {
         color: white !important;
       }
 
@@ -209,9 +196,7 @@
       }
 
       .ant-steps-item-wait,
-      > .ant-steps-item-container
-        > .ant-steps-item-content
-        > .ant-steps-item-description {
+      > .ant-steps-item-container > .ant-steps-item-content > .ant-steps-item-description {
         color: white !important;
       }
 
@@ -236,9 +221,7 @@
         padding-right: 0;
       }
 
-      .ant-steps-item-container
-        > .ant-steps-item-content
-        > .ant-steps-item-title {
+      .ant-steps-item-container > .ant-steps-item-content > .ant-steps-item-title {
         color: white !important;
       }
     }

--- a/src/components/feed/NodeDetails/Status.tsx
+++ b/src/components/feed/NodeDetails/Status.tsx
@@ -11,6 +11,7 @@ const Status = () => {
     const items = pluginStatus.map((label: any, index: number) => {
       return {
         key: index,
+        description: label.description,
         icon: label.process && <Spin />,
         status:
           label.wait === true
@@ -23,36 +24,13 @@ const Status = () => {
       };
     });
 
-    const descriptionItems = pluginStatus.map((label: any, index: number) => {
-      return {
-        key: index,
-        description: label.description,
-        status:
-          label.status === true
-            ? "finish"
-            : label.error === true
-            ? "error"
-            : undefined,
-      };
-    });
-
     return (
-      <>
-        <Steps
+         <Steps
           className="node-details__status"
-          direction="horizontal"
-          size="small"
+          labelPlacement="vertical"
           items={items}
         />
-
-        <Steps
-          direction="horizontal"
-          size="small"
-          className="node-details__status-descriptions"
-          items={descriptionItems}
-        />
-      </>
-    );
+     );
   } else return null;
 };
 

--- a/src/pages/Feeds/components/FeedListView.tsx
+++ b/src/pages/Feeds/components/FeedListView.tsx
@@ -148,9 +148,8 @@ const FeedListView: React.FC = () => {
     <React.Fragment>
       <PageSection className="feed-header" variant="light">
         <InfoIcon
-          title={`New and Existing Analyses (${
-            totalFeedsCount > 0 ? totalFeedsCount : 0
-          })`}
+          title={`New and Existing Analyses (${totalFeedsCount > 0 ? totalFeedsCount : 0
+            })`}
           p1={
             <Paragraph style={style}>
               Analyses (aka ChRIS feeds) are computational experiments where
@@ -168,14 +167,38 @@ const FeedListView: React.FC = () => {
       </PageSection>
 
       <PageSection className="feed-list">
+
         <div className="feed-list__split">
-          <DataTableToolbar
+          <Checkbox
+            id="test"
+            isChecked={selectAllToggle}
+            label="Select all"
+            onChange={() => {
+              if (!selectAllToggle) {
+                if (allFeeds.data) {
+                  dispatch(setAllSelect(allFeeds.data));
+                }
+
+                dispatch(toggleSelectAll(true));
+              } else {
+                if (allFeeds.data) {
+                  dispatch(removeAllSelect(allFeeds.data));
+                }
+                dispatch(toggleSelectAll(false));
+              }
+            }}
+          />
+          
+                    {generatePagination()}
+
+         
+        </div>
+        <div className="feed-list__split">
+        <DataTableToolbar
             onSearch={handleFilterChange}
             label="filter by name"
           />
           {bulkSelect.length > 0 && <IconContainer />}
-
-          {generatePagination()}
         </div>
         {(!data && !loading) || (data && data.length === 0) ? (
           <EmptyStateTable
@@ -196,26 +219,7 @@ const FeedListView: React.FC = () => {
             {
               <Thead>
                 <Tr>
-                  <Th>
-                    <Checkbox
-                      id="test"
-                      isChecked={selectAllToggle}
-                      onChange={() => {
-                        if (!selectAllToggle) {
-                          if (allFeeds.data) {
-                            dispatch(setAllSelect(allFeeds.data));
-                          }
-
-                          dispatch(toggleSelectAll(true));
-                        } else {
-                          if (allFeeds.data) {
-                            dispatch(removeAllSelect(allFeeds.data));
-                          }
-                          dispatch(toggleSelectAll(false));
-                        }
-                      }}
-                    />
-                  </Th>
+                  <Th></Th>
                   <Th>Id</Th>
                   <Th>Analysis</Th>
                   <Th>Created</Th>
@@ -229,7 +233,7 @@ const FeedListView: React.FC = () => {
                   >
                     Size
                   </Th>
-                  <Th></Th>
+                  <Th>Progress</Th>
                 </Tr>
               </Thead>
             }
@@ -314,12 +318,7 @@ const TableRow = ({
   );
 
   const feedSize = (
-    <p
-      style={{
-        textAlign: "center",
-        margin: "0 auto",
-      }}
-    >
+    <p>
       <span className="feed-list__name">
         <Tooltip content={<div>View files in library</div>}>
           <Link to={`/library/`}>
@@ -416,14 +415,14 @@ const TableRow = ({
         backgroundColor: selectedBgRow,
       }}
     >
-      <Td>{bulkChecbox}</Td>
-      <Td>{feedId}</Td>
-      <Td>{name}</Td>
-      <Td>{created}</Td>
-      <Td>{creator}</Td>
-      <Td>{runTime}</Td>
-      <Td>{feedSize}</Td>
-      <Td>{circularProgress}</Td>
+      <Td >{bulkChecbox}</Td>
+      <Td dataLabel="Id" >{feedId}</Td>
+      <Td dataLabel="Analysis" >{name}</Td>
+      <Td dataLabel="Created">{created}</Td>
+      <Td dataLabel="Creator">{creator}</Td>
+      <Td dataLabel="Run Time">{runTime}</Td>
+      <Td dataLabel="Size">{feedSize}</Td>
+      <Td dataLabel="Progress">{circularProgress}</Td>
     </Tr>
   );
 };


### PR DESCRIPTION
- Added responsiveness on the feed view tree 
before: 
<img width="289" alt="Screen Shot 2023-01-24 at 19 05 13" src="https://user-images.githubusercontent.com/37863089/214359632-2d8981dd-286d-44ae-b831-fb8802202812.png">

after: 
<img width="289" alt="Screen Shot 2023-01-24 at 19 04 36" src="https://user-images.githubusercontent.com/37863089/214359437-2ba97050-8586-4f97-824b-a27c07565935.png">


- Added responsiveness on the node tree steps: 
Before:
<img width="289" alt="Screen Shot 2023-01-24 at 19 08 53" src="https://user-images.githubusercontent.com/37863089/214360481-bf8ea97c-c713-409c-a8ee-e3c10c8e97cd.png">

After:
<img width="289" alt=
"Screen Shot 2023-01-24 at 19 06 56" src="https://user-images.githubusercontent.com/37863089/214360049-dc1d0104-02a9-4daf-a357-1963a1e1223b.png">
