### PR TITLE
#884 Close modal when Deleting Feed

### DIFF
--- a/src/pages/Feeds/components/IconContainer.tsx
+++ b/src/pages/Feeds/components/IconContainer.tsx
@@ -159,7 +159,10 @@ const IconContainer = () => {
       dispatch(downloadFeedRequest(bulkSelect, feedName));
     currentAction === "merge" &&
       dispatch(mergeFeedRequest(bulkSelect, feedName));
-    currentAction === "delete" && handleDelete(bulkSelect);
+    if(currentAction === "delete"){
+      handleDelete(bulkSelect);
+      handleModalToggle(false)
+    }
     currentAction === "duplicate" &&
       dispatch(duplicateFeedRequest(bulkSelect, feedName));
     dispatch(toggleSelectAll(false));


### PR DESCRIPTION
@jennydaman  added condition to close the modal when action is delete 
let me know if we need to close the modal on all the other cases , i.e. share , download , merge , duplicate.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/90280586/227745283-7b39e012-dae6-43a2-a65d-a3dc82e063fb.gif)
