### PR TITLE
Add the plugin version and title in the codeblock header

### DIFF
--- a/src/components/catalog/PluginCatalogComponents.tsx
+++ b/src/components/catalog/PluginCatalogComponents.tsx
@@ -361,7 +361,11 @@ export const TabResources = ({
                 <CardHeader>
                   <CardTitle>{compute.data.name}</CardTitle>
                 </CardHeader>
-                <CardBody>{compute.data.description}</CardBody>
+                <CardBody>
+                  {compute.data.description
+                    ? compute.data.description
+                    : "No description for this compute resource"}
+                </CardBody>
               </Card>
             );
           })
@@ -378,8 +382,6 @@ export const TabUseCases = ({ feeds }: { feeds: any[] }) => {
     <List
       style={{
         marginTop: "1.5em",
-        fontSize: "1.1em",
-        background: "#FAFAFA",
       }}
       isBordered
       isPlain

--- a/src/components/feed/CreateFeed/createfeed.scss
+++ b/src/components/feed/CreateFeed/createfeed.scss
@@ -279,3 +279,15 @@ Styles for pipelines
     color: white !important;
   }
 }
+
+.pf-c-code-block__header {
+  display: block;
+}
+.pf-c-code-block__actions {
+  display: block;
+}
+
+.pf-c-code-block__actions-item {
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/components/feed/NodeDetails/NodeDetails.tsx
+++ b/src/components/feed/NodeDetails/NodeDetails.tsx
@@ -339,6 +339,7 @@ function getCommand(
         instanceParameters[i].data.param_name === pluginParameters[j].data.name
       ) {
         const boolean = instanceParameters[i].data.type === "boolean";
+
         modifiedParams.push({
           name: pluginParameters[j].data.flag,
           value: boolean ? "" : instanceParameters[i].data.value,

--- a/src/components/feed/Pipelines/ClipboardCopyCommand.tsx
+++ b/src/components/feed/Pipelines/ClipboardCopyCommand.tsx
@@ -6,14 +6,21 @@ import {
   CodeBlockAction,
   clipboardCopyFunc,
 } from "@patternfly/react-core";
-
 import { SinglePipeline } from "../CreateFeed/types/pipeline";
 
 const ClipboardCopyCommand = ({ state }: { state: SinglePipeline }) => {
   const [copied, setCopied] = React.useState(false);
 
-  const { currentNode, parameterList } = state;
+  const { currentNode, parameterList, pluginPipings } = state;
+
   const params = parameterList && currentNode && parameterList[currentNode];
+  const pluginPiping =
+    state.pluginPipings &&
+    state.pluginPipings.filter((piping) => {
+      if (currentNode && piping.data.id === currentNode) {
+        return piping;
+      }
+    });
 
   let generatedCommand = "";
 
@@ -25,6 +32,8 @@ const ClipboardCopyCommand = ({ state }: { state: SinglePipeline }) => {
       const defaultValue =
         params[input].default === false || params[input].default === true
           ? ""
+          : params[input].default.length === 0
+          ? "''"
           : params[input].default;
       generatedCommand += ` --${name} ${defaultValue}`;
     }
@@ -38,6 +47,11 @@ const ClipboardCopyCommand = ({ state }: { state: SinglePipeline }) => {
   const actions = (
     <React.Fragment>
       <CodeBlockAction>
+        <span style={{ margin: "0.5em" }}>
+          {pluginPiping && pluginPiping.length > 0
+            ? `${pluginPiping[0].data.plugin_name}:${pluginPiping[0].data.plugin_version}`
+            : "N/A"}
+        </span>
         <ClipboardCopyButton
           id="basic-copy-button"
           textId="code-content"

--- a/src/components/feed/Pipelines/NodeData.tsx
+++ b/src/components/feed/Pipelines/NodeData.tsx
@@ -105,7 +105,7 @@ const NodeData = (props: NodeProps) => {
   }, [orientation, position]);
 
   const textLabel = (
-    <g id={`text_${data.id}`} transform={`translate(-50,30)`}>
+    <g id={`text_${data.id}`} transform={`translate(-30,30)`}>
       <text ref={textRef} className="label__title">
         {titleName ? titleName : data.title}
       </text>

--- a/src/components/feed/Pipelines/NodeData.tsx
+++ b/src/components/feed/Pipelines/NodeData.tsx
@@ -105,11 +105,9 @@ const NodeData = (props: NodeProps) => {
   }, [orientation, position]);
 
   const textLabel = (
-    <g id={`text_${data.id}`} transform={`translate(-60,30)`}>
+    <g id={`text_${data.id}`} transform={`translate(-50,30)`}>
       <text ref={textRef} className="label__title">
-        {`${titleName ? titleName : data.title} (${data.plugin_name}:${
-          data.plugin_version
-        })`}
+        {titleName ? titleName : data.title}
       </text>
     </g>
   );

--- a/src/pages/DataLibrary/components/UserLibrary/Browser.tsx
+++ b/src/pages/DataLibrary/components/UserLibrary/Browser.tsx
@@ -218,30 +218,38 @@ function FileCard({ file, browserType }: { file: any; browserType: string }) {
     setLargePreview(!largePreview);
   };
 
+  console.log("LargePreview", largePreview);
+
   return (
     <>
       <Card
         onClick={(e) => {
-          const path = file.data.fname;
-          const folder = {
-            path,
-            name: fileName,
-          };
-          const previousPath = fileNameArray
-            .slice(0, fileNameArray.length - 1)
-            .join("/");
+          if (!largePreview) {
+            const path = file.data.fname;
+            const folder = {
+              path,
+              name: fileName,
+            };
+            const previousPath = fileNameArray
+              .slice(0, fileNameArray.length - 1)
+              .join("/");
 
-          handleOnClick(
-            e,
-            previousPath,
-            path,
-            folder,
-            browserType,
-            "file",
-            handlePreview
-          );
+            handleOnClick(
+              e,
+              previousPath,
+              path,
+              folder,
+              browserType,
+              "file",
+              handlePreview
+            );
+          }
         }}
-        onMouseDown={handleOnMouseDown}
+        onMouseDown={() => {
+          if (!largePreview) {
+            handleOnMouseDown();
+          }
+        }}
         key={file.data.fname}
         isRounded
         isSelectableRaised
@@ -281,10 +289,10 @@ function FileCard({ file, browserType }: { file: any; browserType: string }) {
         </CardBody>
         {largePreview && (
           <Modal
+            className="library-preview"
             variant={ModalVariant.large}
             title="Preview"
             aria-label="viewer"
-            width={"50%"}
             isOpen={largePreview}
             onClose={() => setLargePreview(false)}
           >

--- a/src/pages/DataLibrary/components/UserLibrary/user-library.scss
+++ b/src/pages/DataLibrary/components/UserLibrary/user-library.scss
@@ -57,6 +57,6 @@
   border-radius: 4px;
 }
 
-.pf-c-modal-box.pf-m-md {
-  height: 40%;
+.library-preview > .pf-c-button {
+  right: 3em;
 }

--- a/src/pages/SinglePluginPage/SinglePlugin.tsx
+++ b/src/pages/SinglePluginPage/SinglePlugin.tsx
@@ -93,7 +93,11 @@ const SinglePlugin = () => {
             id: param.data.id,
             paramName: param.data.name,
             type: param.data.type,
-            value: param.data.default ? param.data.default : "",
+            value: param.data.default
+              ? param.data.default
+              : param.data.type !== "boolean"
+              ? "''"
+              : "",
           },
         };
         generatedCommand += unpackParametersIntoString(generateInput);
@@ -149,7 +153,7 @@ const SinglePlugin = () => {
     <Wrapper>
       {!currentPluginMeta ? (
         <div style={{ margin: "auto" }}>
-          <Spinner isSVG diameter="80px" />
+          <Spinner style={{ background: "inherit" }} isSVG diameter="80px" />
         </div>
       ) : (
         <>


### PR DESCRIPTION
This PR add's the version and title of the selected plugin piping in the codeblock header.

![Screenshot from 2023-03-28 15-05-53](https://user-images.githubusercontent.com/15992276/228341696-f3a98365-bc82-4abb-93a9-19b8e9e97de4.png)


It also fixes the cli parameters for "string" parameter types. For an empty default value, the UI visually shows an empty string. 

![Screenshot from 2023-03-28 15-02-31](https://user-images.githubusercontent.com/15992276/228341199-e947afed-5067-40f6-adf5-42e8e31d88be.png)
