### PR TITLE
enables searching plugins by name,title and category

### DIFF
--- a/src/components/catalog/PluginCatalog.tsx
+++ b/src/components/catalog/PluginCatalog.tsx
@@ -42,7 +42,7 @@ const PluginCatalog = () => {
       const params = {
         limit: perPage,
         offset: offset,
-        name: search,
+        name_title_category: search,
       };
       const client = ChrisAPIClient.getClient();
       const pluginList = await client.getPluginMetas(params);


### PR DESCRIPTION
This Pr enables plugins to be searched by name, title and category other than name alone 
Before
![Screenshot from 2023-04-04 18-45-04](https://user-images.githubusercontent.com/109106904/229854880-d3fde25b-9125-4833-b35d-e3bf4dcc0976.png)
![Screenshot from 2023-04-04 18-46-03](https://user-images.githubusercontent.com/109106904/229854921-a5c0e2a5-7d85-4900-9bf3-00529a8fbeba.png)
After 