### PR TITLE
Improve the FileBrowser Download experience

### DIFF
--- a/src/components/feed/FeedOutputBrowser/FileBrowser.tsx
+++ b/src/components/feed/FeedOutputBrowser/FileBrowser.tsx
@@ -43,7 +43,7 @@ import {
 import { setFilePreviewPanel } from "../../../store/drawer/actions";
 import XtkViewer from "../../detailedView/displays/XtkViewer/XtkViewer";
 import { notification } from "antd";
-import { DotsIndicator } from "../../common/dots";
+import { Spin } from "antd";
 
 const getFileName = (name: any) => {
   return name.split("/").slice(-1);
@@ -93,7 +93,7 @@ const FileBrowser = (props: FileBrowserProps) => {
       fileName = item;
     } else {
       currentStatus = status[item.data.fname];
-      isBuffering = currentStatus >= 0 ? true : false;
+      isBuffering = currentStatus == 0 ? true : false;
 
       fileName = getFileName(item.data.fname);
       if (fileName.indexOf(".") > -1) {
@@ -102,7 +102,6 @@ const FileBrowser = (props: FileBrowserProps) => {
       fsize = bytesToSize(item.data.fsize);
       icon = getIcon(type);
     }
-
     const fileNameComponent = (
       <div
         className={`file-browser__table--fileName 
@@ -120,9 +119,9 @@ const FileBrowser = (props: FileBrowserProps) => {
     const size = {
       title: fsize,
     };
-
-    const downloadComponent =
-      typeof item === "string" ? undefined : (
+    const downloadComponent = isBuffering? (
+      <Spin size="small" />
+      ):typeof item !== "string" && currentStatus === undefined? (
         <MdFileDownload
           style={{
             fontSize: "1.25rem",
@@ -135,19 +134,15 @@ const FileBrowser = (props: FileBrowserProps) => {
             handleDownloadClick(e, item);
           }}
         />
-      );
+      ): currentStatus > 0?(
+          <Progress
+           size="small"
+           type="line"
+           percent={currentStatus} />
+      ): undefined;
 
-    const statusComponent =
-      typeof item !== "string" && item && currentStatus > 0 ? (
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-          }}
-        >
-          <Progress size="small" percent={currentStatus} />
-          <AiOutlineClose
+      const cancelComponent = typeof item !== "string" && item && currentStatus > 0 && currentStatus < 100 ? (
+        <AiOutlineClose
             style={{
               color: "red",
               marginLeft: "0.25rem",
@@ -155,19 +150,16 @@ const FileBrowser = (props: FileBrowserProps) => {
             onClick={(event) => {
               event.stopPropagation();
               FileViewerModel.abortControllers[item.data.fname].abort();
-            }}
+             }}
           />
-        </div>
-      ) : isBuffering ? (
-        <DotsIndicator />
-      ) : undefined;
+      ):undefined
 
     const download = {
       title: downloadComponent,
     };
 
     const statusRow = {
-      title: statusComponent,
+      title: cancelComponent,
     };
 
     return {

--- a/src/components/feed/FeedOutputBrowser/FileBrowser.tsx
+++ b/src/components/feed/FeedOutputBrowser/FileBrowser.tsx
@@ -120,7 +120,7 @@ const FileBrowser = (props: FileBrowserProps) => {
       title: fsize,
     };
     const downloadComponent = isBuffering? (
-      <Spin size="small" />
+      <Spin size="small" tip="Preparing to download" />
       ):typeof item !== "string" && currentStatus === undefined? (
         <MdFileDownload
           style={{


### PR DESCRIPTION
- I updated the UI to remove the download icon on each file once a user clicks the download icon. 
- I could not add the circular progress bar as expected as Chris Ui currently is using an older version which does not allow me to use the latest features. 
After:
https://github.com/FNNDSC/ChRIS_ui/assets/37863089/3487020b-af37-4e62-b5c7-9778f6b59b65

I also realised the user experience issue when downloading the parent.zip folder. From the research I have done, the total files retrieved from the item size is way bigger than the total loaded files on the zip folder causing the progress to be stacked on zero for a long time. I tried to see if it is possible to retrieve the file size before downloading the file but the API does not allow me to access the headers. So I think the problem is on the backend. Also, the content type for the zip file is application/JSON, doesn't it have to be application/zip? Not sure how it affects, but I guess it can also be one of the reason

![Screen Shot 2023-06-09 at 21 36 42](https://github.com/FNNDSC/ChRIS_ui/assets/37863089/6f009b30-1de2-4796-aee9-30ac2938d2c7)

And this is different from other files like output.meta.json where the content type is JSON as expected and the total loaded files are equal to the item size

![Screen Shot 2023-06-09 at 21 44 23](https://github.com/FNNDSC/ChRIS_ui/assets/37863089/e986ced1-c02d-40ae-af32-16ef56dad5ce)

