### PR TITLE
Allow catalog and plugins to be browsed without logging in

### DIFF
--- a/src/pages/Layout/PageWrapper.tsx
+++ b/src/pages/Layout/PageWrapper.tsx
@@ -7,8 +7,9 @@ import { IUserState } from "../../store/user/types";
 import { onSidebarToggle, setIsNavOpen } from "../../store/ui/actions";
 import { Page } from "@patternfly/react-core";
 import Header from "./Header";
-import Sidebar from "./Sidebar";
+import Sidebar, { AnonSidebar } from "./Sidebar";
 import "./PageWrapper.scss";
+import { useTypedSelector } from "../../store/hooks";
 
 interface IOtherProps {
   children: any;
@@ -35,11 +36,14 @@ const Wrapper: React.FC<AllProps> = (props: AllProps) => {
     }
   };
 
+  const isLoggedIn = useTypedSelector(({ user }) => user.isLoggedIn);
+  const sidebar = isLoggedIn ? <Sidebar isNavOpen={props.isNavOpen} /> : <AnonSidebar isNavOpen={props.isNavOpen} />;
+
   return (
     <Page
       onPageResize={onPageResize}
       header={<Header onNavToggle={onNavToggle} user={user} />}
-      sidebar={<Sidebar isNavOpen={props.isNavOpen} />}
+      sidebar={sidebar}
     >
       {children}
     </Page>

--- a/src/pages/Layout/Sidebar.tsx
+++ b/src/pages/Layout/Sidebar.tsx
@@ -113,7 +113,7 @@ const Sidebar: React.FC<AllProps> = ({
             </>
           )}
         </NavGroup>
-          
+
           */}
 
         {process.env.REACT_APP_ALPHA_FEATURES === "development" && (
@@ -139,5 +139,23 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   setSidebarActive: (active: { activeItem: string }) =>
     dispatch(setSidebarActive(active)),
 });
+
+
+const AnonSidebarImpl : React.FC<AllProps> = ({
+  isNavOpen,
+}: AllProps) => {
+  const body = (
+    <div style={{color: "white"}}>
+      Please log in to use all features.
+    </div>
+  );
+  return (
+    <PageSidebar theme="dark" isNavOpen={isNavOpen} nav={body} />
+  )
+}
+
+const AnonSidebar = connect(mapStateToProps, mapDispatchToProps)(AnonSidebarImpl);
+export { AnonSidebar };
+
 
 export default connect(mapStateToProps, mapDispatchToProps)(Sidebar);

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -74,17 +74,13 @@ export const MainRouter: React.FC = () => {
     {
       path: "catalog",
       element: (
-        <PrivateRoute>
-          <CatalogPage />
-        </PrivateRoute>
+        <CatalogPage />
       ),
     },
     {
       path: "plugin/:id",
       element: (
-        <PrivateRoute>
-          <SinglePlugin />
-        </PrivateRoute>
+        <SinglePlugin />
       ),
     },
     {


### PR DESCRIPTION
- Removed `<PrivateRoute>` wrappers from the elements of `/catalog` and `/plugin/*` routes
- Clicking on sidebar nav items when not logged in causes error, so the sidebar is now disabled when not logged in.

![image](https://github.com/FNNDSC/ChRIS_ui/assets/20404439/86ce8cd1-4d73-458c-9343-b30243d2dae9)
