### PR TITLE
Improving the Pull Study Workflow 

### DIFF
--- a/src/components/Pacs/components/PatientCard.tsx
+++ b/src/components/Pacs/components/PatientCard.tsx
@@ -20,7 +20,7 @@ const PatientCard = ({ queryResult }: { queryResult: any }) => {
   const patient = queryResult[0];
   const patientDetails = getPatientDetails(patient);
   const [isPatientExpanded, setIsPatientExpanded] = useState(
-    state.shouldDefaultExpanded || false
+    state.shouldDefaultExpanded || false,
   );
   const { PatientID, PatientName, PatientBirthDate, PatientSex } =
     patientDetails;
@@ -44,7 +44,11 @@ const PatientCard = ({ queryResult }: { queryResult: any }) => {
 
   return (
     <>
-      <Card isRounded isExpanded={isPatientExpanded}>
+      <Card
+        
+        isRounded
+        isExpanded={isPatientExpanded}
+      >
         <CardHeader onExpand={() => setIsPatientExpanded(!isPatientExpanded)}>
           <Grid hasGutter style={{ width: "100%" }}>
             <GridItem lg={4} md={4} sm={12}>
@@ -65,7 +69,7 @@ const PatientCard = ({ queryResult }: { queryResult: any }) => {
               <div>
                 Latest Study Date: (
                 {LatestDate(
-                  queryResult.map((s: any) => s.StudyDate.value)
+                  queryResult.map((s: any) => s.StudyDate.value),
                 ).toDateString()}
                 )
               </div>

--- a/src/components/Pacs/components/StudyCard.tsx
+++ b/src/components/Pacs/components/StudyCard.tsx
@@ -24,7 +24,7 @@ const StudyCard = ({ study }: { study: any }) => {
   const [isFetching, setIsFetching] = useState(false);
   const [fetchNextStatus, setFetchNextStatus] = useState(false);
   const { seriesPreviews, preview, selectedPacsService } = state;
-
+  const [allCompleted, setAllCompleted] = useState(true);
   const query = {
     AccessionNumber: study.AccessionNumber.value,
     StudyInstanceUID: study.StudyInstanceUID.value,
@@ -41,8 +41,28 @@ const StudyCard = ({ study }: { study: any }) => {
             study.NumberOfStudyRelatedInstances.value,
             true,
           );
+
+          dispatch({
+            type: Types.SET_SERIES_STATUS,
+            payload: {
+              status: stepperStatus,
+            },
+          });
+
+          let allCompleted = true;
+
+          for (const [, seriesData] of stepperStatus) {
+            if (seriesData.progress.currentStep !== "completed") {
+              allCompleted = false;
+              break;
+            }
+          }
+
+          if (allCompleted) {
+            setIsFetching(false);
+            setFetchNextStatus(!fetchNextStatus);
+          }
         } catch (error) {
-          console.log("Error", error);
           setIsFetching(false);
         } finally {
           setIsFetching(false);

--- a/src/components/Pacs/components/useInterval.tsx
+++ b/src/components/Pacs/components/useInterval.tsx
@@ -1,0 +1,27 @@
+import { useEffect, useRef } from "react";
+
+export default function useInterval(
+  callback: () => void,
+  delay: number | null,
+): void {
+  const savedCallback = useRef<() => void | null>();
+
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    function tick() {
+      if (savedCallback.current) {
+        savedCallback.current();
+      }
+    }
+
+    if (delay !== null) {
+      const id = setInterval(tick, delay);
+      return () => {
+        clearInterval(id);
+      };
+    }
+  }, [delay]);
+}

--- a/src/components/Pacs/context/index.tsx
+++ b/src/components/Pacs/context/index.tsx
@@ -21,8 +21,9 @@ export enum Types {
   SET_DEFAULT_EXPANDED = "SET_DEFAULT_EXPANDED",
   SET_SHOW_PREVIEW = "SET_SHOW_PREVIEW",
   SET_SERIES_PREVIEWS = "SET_SERIES_PREVIEWS",
-  RESET_SERIES_PREVIEWS='RESET_SERIES_PREVIEWS'
-  SET_SERIES_STATUS='SET_SERIES_STATUS'
+  RESET_SERIES_PREVIEWS = "RESET_SERIES_PREVIEWS",
+  SET_SERIES_STATUS = "SET_SERIES_STATUS",
+  RESET_SERIES_STATUS = "RESET_SERIES_STATUS"
 }
 
 interface PacsQueryState {
@@ -36,7 +37,7 @@ interface PacsQueryState {
   seriesPreviews: {
     [key: string]: boolean;
   };
-  seriesStatus : {}
+  seriesStatus: Record<string, any>;
 }
 
 type PacsQueryPayload = {
@@ -77,14 +78,17 @@ type PacsQueryPayload = {
     seriesID: number;
     preview: boolean;
   };
-  
+
   [Types.RESET_SERIES_PREVIEWS]: {
     clearSeriesPreview: boolean;
   };
 
   [Types.SET_SERIES_STATUS]: {
-    status: Record<string, any[]>
-  }
+    status: Record<string, any[]>;
+    studyInstanceUID: string;
+  };
+
+  [Types.RESET_SERIES_STATUS]: Record<any, unknown>;
 };
 
 export type PacsQueryActions =
@@ -110,7 +114,7 @@ const initialState = {
   shouldDefaultExpanded: false,
   preview: false,
   seriesPreviews: {},
-  seriesStatus: new Map()
+  seriesStatus: {},
 };
 
 export function getIndex(value: string) {
@@ -202,26 +206,35 @@ const pacsQueryReducer = (state: PacsQueryState, action: PacsQueryActions) => {
     }
 
     case Types.RESET_SERIES_PREVIEWS: {
-     
       return {
         ...state,
         seriesPreviews: {},
       };
     }
 
+    case Types.SET_SERIES_STATUS: {
+      const { studyInstanceUID, status } = action.payload;
+      const newSeriesStatus = state.seriesStatus[studyInstanceUID]
+        ? {
+            [studyInstanceUID]: {
+              ...state.seriesStatus[studyInstanceUID],
+              ...status,
+            },
+          }
+        : { [studyInstanceUID]: status };
 
-  case Types.SET_SERIES_STATUS : {
-    
-
-    const newSeriesStatus = new Map([...state.seriesStatus, ...action.payload.status]);
-    
- 
-    return {
-      ...state,
-      seriesStatus:newSeriesStatus
+      return {
+        ...state,
+        seriesStatus: newSeriesStatus,
+      };
     }
-    break;
-  }
+
+    case Types.RESET_SERIES_STATUS: {
+      return {
+        ...state,
+        seriesStatus: {},
+      };
+    }
 
     default:
       return state;

--- a/src/components/Pacs/context/index.tsx
+++ b/src/components/Pacs/context/index.tsx
@@ -22,6 +22,7 @@ export enum Types {
   SET_SHOW_PREVIEW = "SET_SHOW_PREVIEW",
   SET_SERIES_PREVIEWS = "SET_SERIES_PREVIEWS",
   RESET_SERIES_PREVIEWS='RESET_SERIES_PREVIEWS'
+  SET_SERIES_STATUS='SET_SERIES_STATUS'
 }
 
 interface PacsQueryState {
@@ -35,6 +36,7 @@ interface PacsQueryState {
   seriesPreviews: {
     [key: string]: boolean;
   };
+  seriesStatus : {}
 }
 
 type PacsQueryPayload = {
@@ -79,6 +81,10 @@ type PacsQueryPayload = {
   [Types.RESET_SERIES_PREVIEWS]: {
     clearSeriesPreview: boolean;
   };
+
+  [Types.SET_SERIES_STATUS]: {
+    status: Record<string, any[]>
+  }
 };
 
 export type PacsQueryActions =
@@ -104,6 +110,7 @@ const initialState = {
   shouldDefaultExpanded: false,
   preview: false,
   seriesPreviews: {},
+  seriesStatus: new Map()
 };
 
 export function getIndex(value: string) {
@@ -195,12 +202,26 @@ const pacsQueryReducer = (state: PacsQueryState, action: PacsQueryActions) => {
     }
 
     case Types.RESET_SERIES_PREVIEWS: {
-      console.log("RESET REDUCER")
+     
       return {
         ...state,
         seriesPreviews: {},
       };
     }
+
+
+  case Types.SET_SERIES_STATUS : {
+    
+
+    const newSeriesStatus = new Map([...state.seriesStatus, ...action.payload.status]);
+    
+ 
+    return {
+      ...state,
+      seriesStatus:newSeriesStatus
+    }
+    break;
+  }
 
     default:
       return state;

--- a/src/components/Pacs/index.tsx
+++ b/src/components/Pacs/index.tsx
@@ -39,7 +39,7 @@ const PacsCopy = () => {
     dispatch(
       setSidebarActive({
         activeItem: "pacs",
-      })
+      }),
     );
   }, [dispatch]);
 
@@ -79,7 +79,7 @@ const QueryBuilder = () => {
       navigateToDifferentRoute: boolean,
       currentQueryType: string,
       value: string,
-      selectedPacsService: string = "default"
+      selectedPacsService: string = "default",
     ) => {
       if (value.length > 0 && currentQueryType) {
         dispatch({
@@ -94,7 +94,7 @@ const QueryBuilder = () => {
             {
               [currentQueryType]: value.trimStart().trimEnd(),
             },
-            selectedPacsService
+            selectedPacsService,
           );
 
           if (response) {
@@ -114,7 +114,7 @@ const QueryBuilder = () => {
 
             if (navigateToDifferentRoute) {
               navigate(
-                `/pacs?queryType=${currentQueryType}&value=${value}&service=${selectedPacsService}`
+                `/pacs?queryType=${currentQueryType}&value=${value}&service=${selectedPacsService}`,
               );
             }
           }
@@ -129,11 +129,11 @@ const QueryBuilder = () => {
         }
       } else {
         setErrorState(
-          "Please ensure PACS service, Search Value, and the Query Type are all selected."
+          "Please ensure PACS service, Search Value, and the Query Type are all selected.",
         );
       }
     },
-    [dispatch, navigate]
+    [dispatch, navigate],
   );
 
   React.useEffect(() => {
@@ -161,7 +161,7 @@ const QueryBuilder = () => {
       .catch((error: any) => {
         setErrorState(error.message);
       });
-    
+
     if (!queryType) {
       dispatch({
         type: Types.SET_CURRENT_QUERY_TYPE,
@@ -170,12 +170,9 @@ const QueryBuilder = () => {
         },
       });
     }
-
-   
-  }, [dispatch, service,queryType]);
+  }, [dispatch, service, queryType]);
 
   React.useEffect(() => {
-    
     const searchValue = searchParams.get("value");
     if (
       Object.keys(queryResult).length === 0 &&
@@ -296,7 +293,7 @@ const QueryBuilder = () => {
                     true,
                     currentQueryType,
                     value,
-                    selectedPacsService
+                    selectedPacsService,
                   );
               }}
               onChange={(_event, value) => setValue(value)}
@@ -357,7 +354,7 @@ const QueryBuilder = () => {
                   true,
                   currentQueryType,
                   value,
-                  selectedPacsService
+                  selectedPacsService,
                 );
               }}
             >
@@ -394,7 +391,9 @@ const Results = () => {
       (queryResult.data && Object.keys(queryResult.data).length === 0) ? (
         <EmptyStateComponent />
       ) : (
-        <PatientCard queryResult={queryResult.data} />
+        <div className="result-grid">
+          <PatientCard queryResult={queryResult.data} />
+        </div>
       )}
     </>
   );

--- a/src/components/Pacs/pacs-copy.css
+++ b/src/components/Pacs/pacs-copy.css
@@ -1,26 +1,26 @@
-article {
-  max-width: 1400px;
-  margin: 0.5em auto;
-  padding: 1em 1em;
-  width: 100%;
+.result-grid,
+.patient-studies,
+.patient-series {
+  margin-top: 1em;
+}
+
+.result-grid {
+  padding-top: 1em;
+  padding-bottom: 1em;
 }
 
 .patient-studies,
 .patient-series {
-  margin-top: 1em;
   padding: 1em 2em;
   border-right: 0.5px solid lightgray;
   border-left: 0.5px solid lightgray;
-}
-
-.study-detail-title {
-  font-weight: 600;
 }
 
 .pf-v5-c-card__header-main {
   flex: 1;
   display: flex;
   flex-flow: wrap;
+  justify-content: space-between;
 }
 
 @media (min-width: 769px) {
@@ -33,24 +33,39 @@ article {
   margin-top: 1rem;
 }
 
-.buttonContainer {
-  padding-left: 1rem;
+.flex-studies-item {
+  width: 18%;
+  margin-left: 0.5em;
 }
 
-.flex-series-container {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
+.button-with-margin {
+  margin-top: 0.25em;
 }
 
 .flex-series-item {
-  flex: 1;
-  box-sizing: border-box;
-  max-width: 350px; /* Set your desired maximum width for each flex-series-item */
-  margin: 0 5px; /* Adjust the margin as needed */
+  width: 15%;
+  margin-left: 1em;
 }
 
-.flex-series-item.steps-container {
-  flex: 3; /* Adjust the flex value to allocate more space for the Steps container */
-  max-width: none; /* Allow the Steps container to take the full available width */
+.steps-container {
+  flex: 2;
+}
+
+.flex-series-item.button-container {
+  flex: 1;
+  margin-left: 1.5em;
+}
+
+@media (max-width: 600px) {
+  .flex-series-item {
+    width: 100%; /* Set full width for all elements on smaller screens */
+  }
+
+  .flex-series-item.steps-container {
+    flex: 1; /* Adjust the flex value for steps container on smaller screens */
+  }
+
+  .flex-series-item.button-container {
+    flex: 1; /* Adjust the flex value for button container on smaller screens */
+  }
 }

--- a/src/components/Pacs/pfdcmClient.tsx
+++ b/src/components/Pacs/pfdcmClient.tsx
@@ -61,8 +61,6 @@ class PfdcmClient {
         retreive,
       );
 
-      console.log("Stepper Status", stepperStatus);
-
       return stepperStatus;
     } catch (error: any) {
       throw new Error(error);
@@ -233,6 +231,7 @@ class PfdcmClient {
 
       return stepperStatus;
     } catch (error: any) {
+      console.log("Error", error);
       throw new Error(error);
     }
   }
@@ -269,6 +268,7 @@ class PfdcmClient {
           if (series.images.requested.count === -1) {
             images.requested = 0;
             imagestatus.request = false;
+            progressMap.set(currentSeries, { imagestatus, images });
             break;
           }
 

--- a/src/components/Pacs/pfdcmClient.tsx
+++ b/src/components/Pacs/pfdcmClient.tsx
@@ -23,7 +23,12 @@ class PfdcmClient {
     }
   }
 
-  async status(query: any, selectedPacsService: string) {
+  async pullStudyStatus(
+    query: any,
+    selectedPacsService: string,
+    requestedFiles: number,
+    retreive: boolean,
+  ) {
     const RequestConfig: AxiosRequestConfig = {
       url: `${this.url}api/v1/PACS/sync/pypx/`,
       method: "POST",
@@ -47,99 +52,18 @@ class PfdcmClient {
     try {
       const response = (await axios(RequestConfig)).data;
 
-      const imagestatus = {
-        request: false,
-        pack: false,
-        push: false,
-        register: false,
-      };
-
-      const currentStatus = {
-        currentStep: "",
-        progressText: "",
-        currentProgress: 0,
-      };
-
-      if (!response.status)
-        return {
-          imagestatus,
-          currentStatus,
-        };
-
       const { then } = response.pypx;
 
       const studies = then["00-status"].study;
+      const stepperStatus = this.calculateStatus(
+        studies,
+        requestedFiles,
+        retreive,
+      );
 
-      const images = { requested: 0, packed: 0, pushed: 0, registered: 0 };
+      console.log("Stepper Status", stepperStatus);
 
-      let error = "";
-
-      for (const study of studies) {
-        for (const key in study) {
-          const seriesList = study[key];
-
-          for (const series of seriesList) {
-            error = series.error;
-            if (series.images.requested.count === -1) {
-              images.requested = 0;
-              imagestatus.request = false;
-              break;
-            }
-            images.requested += series.images.requested.count;
-            imagestatus.request = series.images.requested.status;
-
-            if (series.images.packed.count === -1) break;
-            images.packed += series.images.packed.count;
-            imagestatus.pack = series.images.packed.status;
-
-            if (series.images.pushed.count === -1) break;
-            images.pushed += series.images.pushed.count;
-            imagestatus.push = series.images.pushed.status;
-
-            if (series.images.registered.count === -1) break;
-            images.registered += series.images.registered.count;
-            imagestatus.register = series.images.registered.status;
-          }
-        }
-      }
-
-      if (!imagestatus.request) {
-        currentStatus.currentStep = "none";
-        currentStatus.progressText = "";
-        currentStatus.currentProgress = 0;
-      }
-
-      if (imagestatus.request) {
-        if (imagestatus.pack) {
-          currentStatus.currentProgress = images.packed / images.requested;
-          currentStatus.currentStep = "retrieve";
-          currentStatus.progressText = `${images.packed} of ${images.requested}`;
-        }
-
-        if (imagestatus.push) {
-          currentStatus.currentProgress = images.pushed / images.requested;
-          currentStatus.currentStep = "push";
-          currentStatus.progressText = `${images.pushed} of ${images.requested}`;
-        }
-        if (imagestatus.register) {
-          if (images.registered === images.requested) {
-            currentStatus.currentProgress = 1;
-            currentStatus.currentStep = "completed";
-            currentStatus.progressText = "Files are available for this series";
-          } else {
-            currentStatus.currentProgress =
-              images.registered / images.requested;
-            currentStatus.currentStep = "register";
-            currentStatus.progressText = `${images.registered} of ${images.requested}`;
-          }
-        }
-      }
-
-      return {
-        imagestatus,
-        currentStatus,
-        error,
-      };
+      return stepperStatus;
     } catch (error: any) {
       throw new Error(error);
     }
@@ -271,8 +195,9 @@ class PfdcmClient {
   async stepperStatus(
     query: any,
     selectedPacsService: string,
-    requestedFiles: number,
+    requestedFiles?: number,
     retrieve?: boolean,
+    seriesInstanceUID?: string,
   ) {
     const RequestConfig: AxiosRequestConfig = {
       url: `${this.url}api/v1/PACS/sync/pypx/`,
@@ -294,75 +219,93 @@ class PfdcmClient {
       },
     };
 
-    const newImageStatus: {
-      title: string;
-      description: string;
-      status: string;
-      icon?: React.ReactNode;
-    }[] = [
-      {
-        title: "Request",
-        description: "",
-        status: "wait",
-      },
-      {
-        title: "Retrieve",
-        description: "",
-        status: "wait",
-      },
-      { title: "Push", description: "", status: "wait" },
-      {
-        title: "Register",
-        description: "",
-        status: "wait",
-      },
-    ];
+    try {
+      const response = (await axios(RequestConfig)).data;
+      const { then } = response.pypx;
+      const studies = then["00-status"].study;
 
-    const imagestatus = {
-      request: false,
-      pack: false,
-      push: false,
-      register: false,
-    };
+      const stepperStatus = this.calculateStatus(
+        studies,
+        requestedFiles,
+        retrieve,
+        seriesInstanceUID,
+      );
+
+      return stepperStatus;
+    } catch (error: any) {
+      throw new Error(error);
+    }
+  }
+
+  calculateStatus(
+    studies: any[],
+    requestedFiles?: number,
+    retrieve?: boolean,
+    seriesInstanceUID?: string,
+  ) {
+    const statusMap = new Map<string, any>();
+    const progressMap = new Map<string, { imagestatus: any; images: any }>();
 
     let currentStep = "none";
     let currentProgress = 0;
 
-    try {
-      const response = (await axios(RequestConfig)).data;
-      const { then } = response.pypx;
+    for (const study of studies) {
+      for (const key in study) {
+        const seriesList = study[key];
 
-      const studies = then["00-status"].study;
-      const images = { requested: 0, packed: 0, pushed: 0, registered: 0 };
+        for (const [index, series] of seriesList.entries()) {
+          const images = { requested: 0, packed: 0, pushed: 0, registered: 0 };
+          const imagestatus = {
+            request: false,
+            pack: false,
+            push: false,
+            register: false,
+          };
 
-      for (const study of studies) {
-        for (const key in study) {
-          const seriesList = study[key];
+          const currentSeries = seriesInstanceUID
+            ? seriesInstanceUID
+            : series.study.seriesListInStudy.seriesList[index];
 
-          for (const series of seriesList) {
-            if (series.images.requested.count === -1) {
-              images.requested = 0;
-              imagestatus.request = false;
-              break;
-            }
-
-            images.requested += series.images.requested.count;
-            imagestatus.request = series.images.requested.status;
-
-            if (series.images.packed.count === -1) break;
-            images.packed += series.images.packed.count;
-            imagestatus.pack = series.images.packed.status;
-
-            if (series.images.pushed.count === -1) break;
-            images.pushed += series.images.pushed.count;
-            imagestatus.push = series.images.pushed.status;
-
-            if (series.images.registered.count === -1) break;
-            images.registered += series.images.registered.count;
-            imagestatus.register = series.images.registered.status;
+          if (series.images.requested.count === -1) {
+            images.requested = 0;
+            imagestatus.request = false;
+            break;
           }
+
+          images.requested += series.images.requested.count;
+          imagestatus.request = series.images.requested.status;
+
+          if (series.images.packed.count === -1) break;
+          images.packed += series.images.packed.count;
+          imagestatus.pack = series.images.packed.status;
+
+          if (series.images.pushed.count === -1) break;
+          images.pushed += series.images.pushed.count;
+          imagestatus.push = series.images.pushed.status;
+
+          if (series.images.registered.count === -1) break;
+          images.registered += series.images.registered.count;
+          imagestatus.register = series.images.registered.status;
+
+          progressMap.set(currentSeries, { imagestatus, images });
         }
       }
+    }
+
+    for (const [seriesKey, seriesData] of progressMap.entries()) {
+      const newImageStatus: {
+        title: string;
+        description: string;
+        status: string;
+        icon?: React.ReactNode;
+      }[] = [
+        { title: "Request", description: "", status: "wait" },
+        { title: "Retrieve", description: "", status: "wait" },
+        { title: "Push", description: "", status: "wait" },
+        { title: "Register", description: "", status: "wait" },
+      ];
+
+      const { imagestatus, images } = seriesData;
 
       if (!imagestatus.request && retrieve) {
         newImageStatus[0].icon = <Spin />;
@@ -422,16 +365,16 @@ class PfdcmClient {
         }
       }
 
-      return {
-        newImageStatus,
+      statusMap.set(seriesKey, {
+        newImageStatus: newImageStatus,
         progress: {
           currentStep,
           currentProgress,
         },
-      };
-    } catch (error: any) {
-      throw new Error(error);
+      });
     }
+
+    return statusMap;
   }
 }
 export default PfdcmClient;


### PR DESCRIPTION
Pulling a study might be an incomplete workflow as of now, but it is still better than the one deployed on chris-next, which is why I am merging this PR. Currently, pulling a study only initiates the retrieve for all the studies.

When pulling a study, I initiate a retrieve based on the Accession Number and then subsequently poll for status.

One of the series within a study is currently stuck in the 'Register' status. When retrieving a study, does the request automatically register the file for that specific series, or do I need to submit a separate push/registration request on the Accession Number to push and register all the series?