### PR TITLE
Fix the sidebar bug in the niivue page

### DIFF
--- a/src/components/VisualDatasets/index.tsx
+++ b/src/components/VisualDatasets/index.tsx
@@ -102,7 +102,7 @@ const VisualDatasets: React.FunctionComponent = () => {
   // --------------------------------------------------------------------------------
 
   // when the web app is ready, hide the sidebar and set the page title.
-  React.useEffect(() => {
+  useEffect(() => {
     document.title = "Fetal MRI Viewer";
     dispatch(setIsNavOpen(false));
     dispatch(

--- a/src/components/Wrapper/index.tsx
+++ b/src/components/Wrapper/index.tsx
@@ -14,6 +14,7 @@ import "./wrapper.css";
 interface IOtherProps {
   children: any;
   user: IUserState;
+  niivueActive: boolean;
 }
 interface IPropsFromDispatch {
   onSidebarToggle: typeof onSidebarToggle;
@@ -22,7 +23,7 @@ interface IPropsFromDispatch {
 type AllProps = IUiState & IOtherProps & IPropsFromDispatch;
 
 const Wrapper: React.FC<AllProps> = (props: AllProps) => {
-  const { children, user }: IOtherProps = props;
+  const { children, user, niivueActive }: IOtherProps = props;
   const onNavToggle = () => {
     props.setIsNavOpen(!props.isNavOpen);
   };
@@ -34,7 +35,9 @@ const Wrapper: React.FC<AllProps> = (props: AllProps) => {
     if (data.mobileView) {
       props.setIsNavOpen(false);
     }
-    if (!data.mobileView) {
+
+    // The default setting of the niivue viewer is without a sidebar active. It explicitly set's it to false in it's component.
+    if (!data.mobileView && !niivueActive) {
       props.setIsNavOpen(true);
     }
   };
@@ -66,6 +69,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 const mapStateToProps = ({ ui, user }: ApplicationState) => ({
   isNavOpen: ui.isNavOpen,
   loading: ui.loading,
+  niivueActive: ui.sidebarActiveItem === "niivue",
   user,
 });
 


### PR DESCRIPTION
When first navigating to the fetal MRI viewer, the intended UI behavior is to hide the sidebar. However, a bug is observed where the sidebar is set to active in the Wrapper Component. I have fixed this and will clean up the underlying logic later