### PR TITLE
Add optional link to OHIF

### DIFF
--- a/.env
+++ b/.env
@@ -10,6 +10,9 @@ VITE_ALPHA_FEATURES='production'
 # Set PFDCM_URL to the root url of the running pfdcm instance
 VITE_PFDCM_URL="http://localhost:4005/"
 
+# (optional) set URL of an OHIF browser which has the same studies as the PFDCM
+# VITE_OHIF_URL="http://localhost:8042/ohif/"
+
 VITE_PFDCM_CUBEKEY="local"
 VITE_PFDCM_SWIFTKEY="local"
 VITE_SOURCEMAP='false'

--- a/src/components/Pacs/components/StudyCard.tsx
+++ b/src/components/Pacs/components/StudyCard.tsx
@@ -14,6 +14,7 @@ import { DotsIndicator } from "../../Common";
 import FaQuestionCircle from "@patternfly/react-icons/dist/esm/icons/question-circle-icon";
 import DownloadIcon from "@patternfly/react-icons/dist/esm/icons/download-icon";
 import EyeIcon from "@patternfly/react-icons/dist/esm/icons/eye-icon";
+import ThLargeIcon from "@patternfly/react-icons/dist/esm/icons/th-large-icon";
 import SeriesCard from "./SeriesCard";
 import { formatStudyDate } from "./utils";
 import { PacsQueryContext, Types } from "../context";
@@ -180,6 +181,24 @@ const StudyCard = ({ study }: { study: any }) => {
               )}
 
               <div className="flex-studies-item button-container">
+                {import.meta.env.VITE_OHIF_URL && (
+                  <Tooltip content="Open in OHIF">
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      style={{ marginRight: "0.25em" }}
+                      icon={<ThLargeIcon />}
+                      component="a"
+                      href={`${
+                        import.meta.env.VITE_OHIF_URL
+                      }viewer?StudyInstanceUIDs=${
+                        study.StudyInstanceUID.value
+                      }`}
+                      target="_blank"
+                    ></Button>
+                  </Tooltip>
+                )}
+
                 <Tooltip
                   content={
                     preview === true ? "Hide All Previews" : "Show All Previews"


### PR DESCRIPTION
When ChRIS_ui is configured with a URL for OHIF, a button shows up in study cards to open them in OHIF.

https://github.com/FNNDSC/ChRIS_ui/assets/20404439/fcd43fde-930d-40f5-a70f-a18ef57fa1d6

