### PR TITLE
Archive feed fix

### DIFF
--- a/src/components/Feeds/FeedListView.tsx
+++ b/src/components/Feeds/FeedListView.tsx
@@ -237,7 +237,7 @@ const TableSelectable: React.FunctionComponent = () => {
               search={search}
             />
 
-            {feedsToDisplay && <IconContainer allFeeds={feedsToDisplay} />}
+            {feedsToDisplay && <IconContainer />}
           </div>
           {isLoading ||
           isFetching ||


### PR DESCRIPTION
The Archive Feed feature still needs to be fixed due to incorrect polyfills injected by Niivue, leading to an error in our Chris utility package. The `chris-utility` package uses the problematic `forEach` function. For now, the fix is to handle this error, avoid the page crash, and also address the bug in deleting feeds.