### PR TITLE
refactor: Temporary hack to avoid breaking the issue in prod

### DIFF
--- a/src/components/FeedOutputBrowser/FileBrowser.tsx
+++ b/src/components/FeedOutputBrowser/FileBrowser.tsx
@@ -48,6 +48,7 @@ const FileBrowser = (props: FileBrowserProps) => {
   const { pluginFilesPayload, handleFileClick, selected, filesLoading } = props;
   const selectedFile = useTypedSelector((state) => state.explorer.selectedFile);
   const drawerState = useTypedSelector((state) => state.drawers);
+  const feed = useTypedSelector((state) => state.feed.currentFeed.data);
   const dispatch = useDispatch();
   const [currentRowIndex, setCurrentRowIndex] = React.useState(0);
   const { files, folders, path } = pluginFilesPayload;
@@ -78,8 +79,21 @@ const FileBrowser = (props: FileBrowserProps) => {
         // Append the anchor element to the document body
         document.body.appendChild(link);
 
+        // A temporary hack to avoid having this feature break in prod
+
+        await feed?.put({
+          //@ts-ignore
+          //js client needs to be updated
+          public: true,
+        });
+
         // Programmatically trigger the download
         link.click();
+
+        await feed?.put({
+          //@ts-ignore
+          public: false,
+        });
 
         // Remove the anchor element from the document body after the download is initiated
         document.body.removeChild(link);


### PR DESCRIPTION
### Summary

This is a temporary hack which will be reverted as soon as the download feature is stable again. I got ahead of myself while testing the feature on my local dev and merged it to master. There are a couple of users depending on the download right now. 