### PR TITLE
Add back StudyInstanceUID to DataFetchQuery

### DIFF
--- a/src/components/Pacs/components/SeriesCard.tsx
+++ b/src/components/Pacs/components/SeriesCard.tsx
@@ -74,6 +74,7 @@ const SeriesCardCopy = ({ series }: { series: any }) => {
 
   const pullQuery: DataFetchQuery = useMemo(() => {
     return {
+      StudyInstanceUID: StudyInstanceUID.value,
       SeriesInstanceUID: SeriesInstanceUID.value,
     };
   }, [SeriesInstanceUID.value]);

--- a/src/components/Pacs/pfdcmClient.tsx
+++ b/src/components/Pacs/pfdcmClient.tsx
@@ -12,6 +12,7 @@ export interface ImageStatusType {
 
 export interface DataFetchQuery {
   SeriesInstanceUID: string;
+  StudyInstanceUID: string;
 }
 
 class PfdcmClient {


### PR DESCRIPTION
Orthanc is ok with specifying only SeriesInstanceUID, but the BCH FUJI PACS requires StudyInstanceUID and SeriesInstanceUID.