### PR TITLE
Pulling Study Indicator fix

### DIFF
--- a/src/components/Pacs/components/SeriesCard.tsx
+++ b/src/components/Pacs/components/SeriesCard.tsx
@@ -69,15 +69,16 @@ const SeriesCardCopy = ({ series }: { series: any }) => {
   const [isFetching, setIsFetching] = useState(false);
   const [openSeriesPreview, setOpenSeriesPreview] = useState(false);
   const [isPreviewFileAvailable, setIsPreviewFileAvailable] = useState(false);
-
   const seriesInstances = parseInt(NumberOfSeriesRelatedInstances.value);
+  const studyInstanceUID = StudyInstanceUID.value;
+  const seriesInstanceUID = SeriesInstanceUID.value;
 
   const pullQuery: DataFetchQuery = useMemo(() => {
     return {
-      StudyInstanceUID: StudyInstanceUID.value,
-      SeriesInstanceUID: SeriesInstanceUID.value,
+      StudyInstanceUID: studyInstanceUID,
+      SeriesInstanceUID: seriesInstanceUID,
     };
-  }, [SeriesInstanceUID.value]);
+  }, [studyInstanceUID, seriesInstanceUID]);
 
   const { data, isPending, isError, error } = useQuery({
     queryKey: ["pacsFiles", SeriesInstanceUID.value],
@@ -90,7 +91,7 @@ const SeriesCardCopy = ({ series }: { series: any }) => {
   });
 
   useEffect(() => {
-    if (pullStudy && !isFetching) {
+    if (pullStudy?.[studyInstanceUID] && !isFetching) {
       handleRetrieve();
     }
   }, [pullStudy]);

--- a/src/components/Pacs/components/StudyCard.tsx
+++ b/src/components/Pacs/components/StudyCard.tsx
@@ -21,7 +21,7 @@ import {
 import { PacsQueryContext, Types } from "../context";
 import SeriesCard from "./SeriesCard";
 import { CardHeaderComponent } from "./SettingsComponents";
-import { formatStudyDate } from "./utils";
+
 import useSettings from "../useSettings";
 
 const StudyCardCopy = ({ study }: { study: any }) => {
@@ -56,7 +56,10 @@ const StudyCardCopy = ({ study }: { study: any }) => {
         if (allSeriesBeingTracked) {
           dispatch({
             type: Types.SET_PULL_STUDY,
-            payload: null,
+            payload: {
+              studyInstanceUID,
+              status: false,
+            },
           });
         }
       }
@@ -218,7 +221,7 @@ const StudyCardCopy = ({ study }: { study: any }) => {
                   />
                 </Tooltip>
 
-                {pullStudy ? (
+                {pullStudy[studyInstanceUID] ? (
                   <DotsIndicator title="Pulling Study..." />
                 ) : (
                   <Tooltip content="Pull Study">
@@ -226,7 +229,10 @@ const StudyCardCopy = ({ study }: { study: any }) => {
                       onClick={() => {
                         dispatch({
                           type: Types.SET_PULL_STUDY,
-                          payload: null,
+                          payload: {
+                            studyInstanceUID,
+                            status: true,
+                          },
                         });
                         setIsStudyExpanded(true);
                       }}

--- a/src/components/Pacs/context/index.tsx
+++ b/src/components/Pacs/context/index.tsx
@@ -20,9 +20,7 @@ export enum Types {
   SET_LOADING_SPINNER = "SET_LOADING_SPINNER",
   SET_DEFAULT_EXPANDED = "SET_DEFAULT_EXPANDED",
   SET_SHOW_PREVIEW = "SET_SHOW_PREVIEW",
-
   SET_PULL_STUDY = "SET_PULL_STUDY",
-
   SET_STUDY_PULL_TRACKER = "SET_STUDY_PULL_TRACKER",
 }
 
@@ -34,7 +32,9 @@ interface PacsQueryState {
   fetchingResults: { status: boolean; text: string };
   shouldDefaultExpanded: boolean;
   preview: boolean;
-  pullStudy: boolean;
+  pullStudy: {
+    [key: string]: boolean;
+  };
   studyPullTracker: {
     [key: string]: {
       [key: string]: boolean;
@@ -50,7 +50,7 @@ const initialState = {
   fetchingResults: { status: false, text: "" },
   shouldDefaultExpanded: false,
   preview: false,
-  pullStudy: false,
+  pullStudy: {},
   studyPullTracker: {},
 };
 
@@ -89,7 +89,10 @@ type PacsQueryPayload = {
     preview: boolean;
   };
 
-  [Types.SET_PULL_STUDY]: null;
+  [Types.SET_PULL_STUDY]: {
+    studyInstanceUID: string;
+    status: boolean;
+  };
 
   [Types.SET_STUDY_PULL_TRACKER]: {
     studyInstanceUID: string;
@@ -183,12 +186,15 @@ const pacsQueryReducer = (state: PacsQueryState, action: PacsQueryActions) => {
     }
 
     case Types.SET_PULL_STUDY: {
+      const { studyInstanceUID, status } = action.payload;
       return {
         ...state,
-        pullStudy: !state.pullStudy,
+        pullStudy: {
+          ...state.pullStudy,
+          [studyInstanceUID]: status,
+        },
       };
     }
-
     case Types.SET_STUDY_PULL_TRACKER: {
       const { studyInstanceUID, seriesInstanceUID, currentProgress } =
         action.payload;


### PR DESCRIPTION
Summary:

This PR addresses a bug where all studies showed the 'pulling' activity, even when only one was being pulled. Now, only the currently pulling study will display the activity indicator.