### PR TITLE
Update the retrieve performed by the pull study button

### DIFF
--- a/src/components/Pacs/components/StudyCard.tsx
+++ b/src/components/Pacs/components/StudyCard.tsx
@@ -22,12 +22,13 @@ import SeriesCard from "./SeriesCard";
 import { CardHeaderComponent } from "./SettingsComponents";
 
 import useSettings from "../useSettings";
+import PfdcmClient from "../pfdcmClient";
 
 const StudyCardCopy = ({ study }: { study: any }) => {
   const { data, isLoading, isError } = useSettings();
   const { state, dispatch } = useContext(PacsQueryContext);
   const [isStudyExpanded, setIsStudyExpanded] = useState(false);
-  const { preview, pullStudy, studyPullTracker } = state;
+  const { preview, pullStudy, studyPullTracker, selectedPacsService } = state;
   const userPreferences = data?.study;
   const userPreferencesArray = userPreferences && Object.keys(userPreferences);
   const studyInstanceUID = study.StudyInstanceUID.value;
@@ -231,7 +232,12 @@ const StudyCardCopy = ({ study }: { study: any }) => {
               ) : (
                 <Tooltip content="Pull Study">
                   <Button
-                    onClick={() => {
+                    onClick={async () => {
+                      const client = new PfdcmClient();
+                      await client.findRetrieve(selectedPacsService, {
+                        AccessionNumber: study.AccessionNumber.value,
+                      });
+
                       dispatch({
                         type: Types.SET_PULL_STUDY,
                         payload: {

--- a/src/components/Pacs/pfdcmClient.tsx
+++ b/src/components/Pacs/pfdcmClient.tsx
@@ -1,7 +1,6 @@
-import React from "react";
-import axios from "axios";
 import type { AxiosRequestConfig } from "axios";
-import { Spin } from "antd";
+import axios from "axios";
+import React from "react";
 
 export interface ImageStatusType {
   title: string;
@@ -11,8 +10,9 @@ export interface ImageStatusType {
 }
 
 export interface DataFetchQuery {
-  SeriesInstanceUID: string;
-  StudyInstanceUID: string;
+  SeriesInstanceUID?: string;
+  StudyInstanceUID?: string;
+  AccessionNumber?: string;
 }
 
 class PfdcmClient {
@@ -33,7 +33,8 @@ class PfdcmClient {
       const url = `${this.url}api/v1/PACSservice/list/`;
       const response = await axios.get(url);
       return response.data;
-    } catch (error: any) {
+      // setting error as unknown for better type safety
+    } catch (error: unknown) {
       throw error;
     }
   }
@@ -60,8 +61,8 @@ class PfdcmClient {
       if (status) {
         return pypx;
       }
-    } catch (error: any) {
-      throw new Error(error);
+    } catch (error: unknown) {
+      throw error;
     }
   }
 
@@ -69,6 +70,8 @@ class PfdcmClient {
     const RequestConfig: AxiosRequestConfig = {
       url: `${this.url}api/v1/PACS/thread/pypx/`,
       method: "POST",
+      timeout: 10000, //10s
+      timeoutErrorMessage: "Error Request Timeout out",
       headers: {
         Accept: "application/json",
         "Content-Type": "application/json",
@@ -89,8 +92,8 @@ class PfdcmClient {
     try {
       const response = await axios(RequestConfig);
       return response.data.timestamp;
-    } catch (error: any) {
-      throw new Error(error);
+    } catch (error: unknown) {
+      throw error;
     }
   }
 }


### PR DESCRIPTION
Clicking the 'Pull Study' button now performs a 'retrieve' operation using only the Accession Number, avoiding requests at the individual 'series' level. This ensures that the retrieve operations at the series level are sequential. Additionally, I have decreased the polling frequency to avoid overwhelming Cube with network requests for files.