### PR TITLE
 Do not show loading spinners for series with no instances

### DIFF
--- a/src/components/Pacs/components/SeriesCard.tsx
+++ b/src/components/Pacs/components/SeriesCard.tsx
@@ -235,8 +235,7 @@ const SeriesCardCopy = ({ series }: { series: any }) => {
 
   // Retrieve this series if the pull study is clicked and the series is not already being retrieved.
   useEffect(() => {
-    if (pullStudy?.[studyInstanceUID] && !isFetching) {
-      //handleRetrieveMutation.mutate();
+    if (pullStudy?.[studyInstanceUID] && !isFetching && !isDisabled) {
       setIsFetching(true);
     }
   }, [pullStudy]);


### PR DESCRIPTION
When the user hits 'pull study', there could be a series in the study without files. We don't want to poll Cube for files for that particular series.







