### PR TITLE
 Use the shlex package to add quotes to properly quote a string for command line safety

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "redux-saga": "^1.3.0",
         "rusha": "^0.8.14",
         "sanitize-html": "^2.11.0",
+        "shlex": "^2.1.2",
         "sirv-cli": "^2.0.2",
         "typesafe-actions": "^5.1.0",
         "typescript": "^5.3.3",
@@ -10314,6 +10315,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/shlex": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/shlex/-/shlex-2.1.2.tgz",
+      "integrity": "sha512-Nz6gtibMVgYeMEhUjp2KuwAgqaJA1K155dU/HuDaEJUGgnmYfVtVZah+uerVWdH8UGnyahhDCgABbYTbs254+w=="
     },
     "node_modules/siginfo": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "redux-saga": "^1.3.0",
     "rusha": "^0.8.14",
     "sanitize-html": "^2.11.0",
+    "shlex": "^2.1.2",
     "sirv-cli": "^2.0.2",
     "typesafe-actions": "^5.1.0",
     "typescript": "^5.3.3",

--- a/src/components/Common/index.tsx
+++ b/src/components/Common/index.tsx
@@ -14,6 +14,7 @@ import {
   Hint,
   MenuToggle,
   TextInput,
+  ClipboardCopy,
 } from "@patternfly/react-core";
 import { CubesIcon, SearchIcon } from "../Icons";
 import { Alert, Popover, Spin, Typography } from "antd";
@@ -304,5 +305,48 @@ export const ErrorAlert = ({
         />
       }
     />
+  );
+};
+
+export const ClipboardCopyFixed = ({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange?: (_event: any, text?: string | number) => void;
+}) => {
+  const handleCopy = async (_event: any, text: string) => {
+    if (!text) {
+      console.warn("No text provided to copy.");
+      return;
+    }
+
+    if (navigator.clipboard) {
+      try {
+        await navigator.clipboard.writeText(text.toString());
+      } catch (error) {
+        alert("Failed to copy text to clipboard. Please try again.");
+      }
+    } else {
+      console.warn(
+        "Clipboard API not found. This copy function will not work. This is likely because you're using an",
+        "unsupported browser or you're not using HTTPS.",
+      );
+      alert(
+        "Clipboard API is not supported in your browser. Please use a supported browser or enable HTTPS.",
+      );
+    }
+  };
+
+  return (
+    <ClipboardCopy
+      isReadOnly
+      hoverTip="Copy"
+      clickTip="Copied"
+      onCopy={(event) => handleCopy(event, value)}
+      onChange={onChange}
+    >
+      {value}
+    </ClipboardCopy>
   );
 };

--- a/src/components/NodeDetails/NodeDetails.tsx
+++ b/src/components/NodeDetails/NodeDetails.tsx
@@ -24,6 +24,7 @@ import PluginTitle from "./PluginTitle";
 import Status from "./Status";
 import StatusTitle from "./StatusTitle";
 import { getErrorCodeMessage } from "./utils";
+import { quote } from "shlex";
 
 interface INodeState {
   plugin?: Plugin;
@@ -300,7 +301,7 @@ function getCommand(
 
         modifiedParams.push({
           name: pluginParameters[j].data.flag,
-          value: isBoolean ? " " : isString ? `'${value}'` : value,
+          value: isBoolean ? " " : isString ? quote(value) : value,
         });
       }
     }

--- a/src/components/SinglePlugin/PluginCatalogComponents.tsx
+++ b/src/components/SinglePlugin/PluginCatalogComponents.tsx
@@ -424,6 +424,29 @@ export const HeaderSidebar = ({
   currentPluginMeta: PluginMeta;
   removeEmail: (authors: string[]) => string[];
 }) => {
+  const handleCopy = async (_event: any, text: string) => {
+    if (!text) {
+      console.warn("No text provided to copy.");
+      return;
+    }
+
+    if (navigator.clipboard) {
+      try {
+        await navigator.clipboard.writeText(text.toString());
+        console.log("Text copied to clipboard successfully.");
+      } catch (error) {
+        alert("Failed to copy text to clipboard. Please try again.");
+      }
+    } else {
+      console.warn(
+        "Clipboard API not found. This copy function will not work. This is likely because you're using an",
+        "unsupported browser or you're not using HTTPS.",
+      );
+      alert(
+        "Clipboard API is not supported in your browser. Please use a supported browser or enable HTTPS.",
+      );
+    }
+  };
   return (
     <div className="plugin-body-side-col">
       <div className="plugin-body-detail-section">
@@ -432,7 +455,19 @@ export const HeaderSidebar = ({
           install this plugin.
         </p>
 
-        <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied">
+        <ClipboardCopy
+          isReadOnly
+          hoverTip="Copy"
+          clickTip="Copied"
+          onCopy={(event) =>
+            handleCopy(
+              event,
+              parameterPayload?.url
+                ? parameterPayload.url
+                : "Fetching the url...",
+            )
+          }
+        >
           {parameterPayload?.url ? parameterPayload.url : "Fetching the url..."}
         </ClipboardCopy>
       </div>

--- a/src/components/SinglePlugin/PluginCatalogComponents.tsx
+++ b/src/components/SinglePlugin/PluginCatalogComponents.tsx
@@ -433,7 +433,6 @@ export const HeaderSidebar = ({
     if (navigator.clipboard) {
       try {
         await navigator.clipboard.writeText(text.toString());
-        console.log("Text copied to clipboard successfully.");
       } catch (error) {
         alert("Failed to copy text to clipboard. Please try again.");
       }

--- a/src/components/SinglePlugin/PluginCatalogComponents.tsx
+++ b/src/components/SinglePlugin/PluginCatalogComponents.tsx
@@ -8,7 +8,6 @@ import {
   Tabs,
   TabTitleText,
   Tab,
-  ClipboardCopy,
   CodeBlock,
   CodeBlockCode,
   Dropdown,
@@ -29,6 +28,7 @@ import { PluginMeta, Plugin, PluginInstance } from "@fnndsc/chrisapi";
 import { useNavigate } from "react-router";
 import PluginImg from "../../assets/brainy-pointer.png";
 import { Link } from "react-router-dom";
+import { ClipboardCopyFixed } from "../Common";
 
 export const HeaderComponent = ({
   currentPluginMeta,
@@ -424,28 +424,6 @@ export const HeaderSidebar = ({
   currentPluginMeta: PluginMeta;
   removeEmail: (authors: string[]) => string[];
 }) => {
-  const handleCopy = async (_event: any, text: string) => {
-    if (!text) {
-      console.warn("No text provided to copy.");
-      return;
-    }
-
-    if (navigator.clipboard) {
-      try {
-        await navigator.clipboard.writeText(text.toString());
-      } catch (error) {
-        alert("Failed to copy text to clipboard. Please try again.");
-      }
-    } else {
-      console.warn(
-        "Clipboard API not found. This copy function will not work. This is likely because you're using an",
-        "unsupported browser or you're not using HTTPS.",
-      );
-      alert(
-        "Clipboard API is not supported in your browser. Please use a supported browser or enable HTTPS.",
-      );
-    }
-  };
   return (
     <div className="plugin-body-side-col">
       <div className="plugin-body-detail-section">
@@ -454,21 +432,11 @@ export const HeaderSidebar = ({
           install this plugin.
         </p>
 
-        <ClipboardCopy
-          isReadOnly
-          hoverTip="Copy"
-          clickTip="Copied"
-          onCopy={(event) =>
-            handleCopy(
-              event,
-              parameterPayload?.url
-                ? parameterPayload.url
-                : "Fetching the url...",
-            )
+        <ClipboardCopyFixed
+          value={
+            parameterPayload?.url ? parameterPayload.url : "Fetching the url..."
           }
-        >
-          {parameterPayload?.url ? parameterPayload.url : "Fetching the url..."}
-        </ClipboardCopy>
+        />
       </div>
       <div className="plugin-body-detail-section">
         <h4>Repository</h4>


### PR DESCRIPTION
The quote function from` node-shlex` is used to quote values fetched from pluginParameters, ensuring that string values are properly formatted for command-line safety `(type === 'string' ? quote(value) : value)`.