### PR TITLE
Do `npm run test:prepare` in separate GHA step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,6 +87,8 @@ jobs:
         run: npm ci
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
+      - name: Setup tests
+        run: npm run test:prepare
       - name: End-to-End tests
         env:
           TEST_SAFARI: yes


### PR DESCRIPTION
This might help with timing and avoiding timeouts when running tests in GitHub Actions.