### PR TITLE
Add mgz to fileTypes

### DIFF
--- a/src/components/Preview/FileDetailView.tsx
+++ b/src/components/Preview/FileDetailView.tsx
@@ -44,7 +44,20 @@ export interface ActionState {
   [key: string]: boolean | string;
 }
 
-const fileTypes = ["nii", "dcm", "fsm", "crv", "smoothwm", "pial", "nii.gz"];
+/**
+ * List of file extensions of files which should be loaded from the network
+ * and given to the viewer component as base64 data instead of as a URI.
+ */
+const fileTypes = [
+  "nii",
+  "dcm",
+  "fsm",
+  "crv",
+  "smoothwm",
+  "pial",
+  "nii.gz",
+  "mgz",
+];
 
 const FileDetailView = (props: AllProps) => {
   const [tagInfo, setTagInfo] = React.useState<any>();


### PR DESCRIPTION
Possibly fixes a regression introduced in https://github.com/FNNDSC/ChRIS_ui/pull/1127

Some file preview components prefer to receive their data as a URI whereas some prefer to receive their data as a blob. In #1127 a [hard-coded list of file extensions called `fileTypes`](https://github.com/FNNDSC/ChRIS_ui/pull/1127/files#diff-cf48937745af433174b65b1a7745c6faa590b5f643b75068dc0edfec23d5741bR47) was added where files matching those extensions would always be loaded as a blob instead of by URI.

Loading data by URI is usually more efficient but it's not backwards-compatible with NiiVueDisplay.tsx, which wasn't updated in #1127. Here I did a lazy solution of adding `mgz` to `fileTypes` so that it'll work like it used to.