### PR TITLE
security: remove rusha (SHA-1) dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "react-router-dom": "^6.30.1",
     "react-use-websocket": "^4.13.0",
     "redux-saga": "^1.3.0",
-    "rusha": "^0.8.14",
     "sanitize-html": "^2.13.0",
     "shlex": "^2.1.2",
     "typescript": "^5.6.2",

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -2,7 +2,6 @@ declare module "pako";
 declare module "@patternfly/react-log-viewer";
 declare module "xtk";
 declare module "dicom-parser";
-declare module "rusha";
 declare module "hammerjs";
 declare module "preval.macro";
 declare module "@cornerstonejs/dicom-image-loader";


### PR DESCRIPTION
The rusha package is a SHA-1 hashing library listed as a direct dependency but never imported or used anywhere in the source code. Remove it along with its ambient type declaration.

SHA-1 is cryptographically broken and deprecated in favour of the SHA-2 family. No replacement needed as the package was dead code.